### PR TITLE
Add brunch to npm devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "babel-brunch": "~6.0.0",
+    "brunch": "^2.9.1",
     "clean-css-brunch": "~2.0.0",
     "css-brunch": "~2.0.0",
     "javascript-brunch": "~2.0.0",


### PR DESCRIPTION
Ultimately I think we should move away from brunch and use Webpack which is what we all love and know but in the meantime let's add brunch to the package.json as long as it's being used