### PR TITLE
Integration is open for more than Post and remove unused module attributes

### DIFF
--- a/lib/tilex/integrations.ex
+++ b/lib/tilex/integrations.ex
@@ -2,7 +2,7 @@ defmodule Tilex.Integrations do
   @slack_notifier Application.get_env(:tilex, :slack_notifier)
   @twitter_notifier Application.get_env(:tilex, :twitter_notifier)
 
-  def post_notifications(conn, post) do
+  def notify(conn, post = %Tilex.Post{}) do
     developer = Tilex.Repo.one(Ecto.assoc(post, :developer))
     channel = Tilex.Repo.one(Ecto.assoc(post, :channel))
     url = Tilex.Router.Helpers.post_url(conn, :show, post)
@@ -13,6 +13,10 @@ defmodule Tilex.Integrations do
     post_changeset = Ecto.Changeset.change(post, %{tweeted_at: Ecto.DateTime.utc})
     Tilex.Repo.update!(post_changeset)
 
+    conn
+  end
+
+  def notify(conn, _) do
     conn
   end
 end

--- a/web/controllers/post_controller.ex
+++ b/web/controllers/post_controller.ex
@@ -1,9 +1,6 @@
 defmodule Tilex.PostController do
   use Tilex.Web, :controller
 
-  @slack_notifier Application.get_env(:tilex, :slack_notifier)
-  @twitter_notifier Application.get_env(:tilex, :twitter_notifier)
-
   plug :load_channels when action in [:new, :create]
 
   plug Guardian.Plug.EnsureAuthenticated, [handler: __MODULE__] when action in [:new, :create]

--- a/web/controllers/post_controller.ex
+++ b/web/controllers/post_controller.ex
@@ -48,7 +48,7 @@ defmodule Tilex.PostController do
         conn
         |> put_flash(:info, "Post created")
         |> redirect(to: post_path(conn, :index))
-        |> Tilex.Integrations.post_notifications(post)
+        |> Tilex.Integrations.notify(post)
 
       {:error, changeset} ->
         render(conn, "new.html", changeset: changeset)


### PR DESCRIPTION
I have some thoughts on moving the Integration notification system out into its own little "umbrella" if/when we decide to convert to the new Phoenix 1.3 file structure. This is kind of the start of those thoughts. 

So now instead of having a bunch of functions like `post_notifications` and `post_likes` we can just have a generic `notify` and using pattern matching, send it anything we want. It will match and react to what we want, and ignore anything else. 

I also removed a couple module attribute definitions that were leftover from an earlier refactoring. 