### PR TITLE
Developer edits post

### DIFF
--- a/test/controllers/post_controller_test.exs
+++ b/test/controllers/post_controller_test.exs
@@ -10,4 +10,9 @@ defmodule Tilex.PostControllerTest do
     conn = get conn, post_path(conn, :new)
     assert html_response(conn, 302)
   end
+
+  test "throws 404 with slug less than 10 characters", %{conn: conn} do
+    conn = get conn, post_path(conn, :edit, "123456789")
+    assert html_response(conn, 404)
+  end
 end

--- a/test/features/developer_edits_post_test.exs
+++ b/test/features/developer_edits_post_test.exs
@@ -1,0 +1,50 @@
+defmodule DeveloperEditsPostTest do
+  use Tilex.IntegrationCase, async: true
+
+  test "fills out form and updates post from post show", %{session: session} do
+    Factory.insert!(:channel, name: "phoenix")
+    developer = Factory.insert!(:developer)
+    post = Factory.insert!(
+      :post,
+      title: "Awesome Post!",
+      developer: developer,
+      body: "This is how to be awesome!"
+    )
+
+    sign_in(session, developer)
+
+    visit(session, post_path(Endpoint, :show, post))
+
+    click(session, Query.link("edit"))
+
+    h1_heading = Element.text(find(session, Query.css("main header h1")))
+    assert h1_heading == "Edit Post"
+
+    session
+    |> fill_in(Query.text_field("Title"), with: "Even Awesomer Post!")
+    |> fill_in(Query.text_field("Body"), with: "This is how to be super awesome!")
+    |> (fn(session) ->
+      find(session, Query.select("Channel"), fn (element) ->
+        click(element, Query.option("phoenix"))
+      end)
+      session
+    end).()
+    |> click(Query.button("Submit"))
+
+    element_text = fn (session, selector) ->
+      Element.text(find(session, Query.css(selector)))
+    end
+
+    info_flash       = element_text.(session, ".alert-info")
+    post_title       = element_text.(session, ".post h1")
+    post_body        = element_text.(session, ".post .copy")
+    post_footer      = element_text.(session, ".post aside")
+    likes_count      = element_text.(session, ".js-like-action")
+
+    assert info_flash       == "Post Updated"
+    assert post_title       =~ ~r/Even Awesomer Post!/
+    assert post_body        =~ ~r/This is how to be super awesome!/
+    assert post_footer      =~ ~r/#phoenix/i
+    assert likes_count      =~ ~r/1/
+  end
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -36,6 +36,6 @@ defmodule Tilex.Router do
     get "/authors/:name", DeveloperController, :show
 
     get "/", PostController, :index
-    resources "/posts", PostController, only: [:index, :show, :new, :create], param: "titled_slug"
+    resources "/posts", PostController, param: "titled_slug"
   end
 end

--- a/web/templates/post/edit.html.eex
+++ b/web/templates/post/edit.html.eex
@@ -1,0 +1,6 @@
+<section id="post_edit">
+  <header class='page_head'>
+    <h1>Edit Post</h1>
+  </header>
+  <%= render Tilex.PostView, "form.html", channels: @channels, changeset: @changeset, action: post_path(@conn, :update, @post) %>
+</section>

--- a/web/templates/post/form.html.eex
+++ b/web/templates/post/form.html.eex
@@ -1,4 +1,4 @@
-<%= form_for @changeset, post_path(@conn, :create), fn f -> %>
+<%= form_for @changeset, @action, fn f -> %>
   <dl>
     <dt>
       <%= label f, :title %>

--- a/web/templates/post/new.html.eex
+++ b/web/templates/post/new.html.eex
@@ -2,5 +2,5 @@
   <header class='page_head'>
     <h1>Create Post</h1>
   </header>
-  <%= render Tilex.PostView, "form.html", channels: @channels, conn: @conn, changeset: @changeset %>
+  <%= render Tilex.PostView, "form.html", channels: @channels, changeset: @changeset, action: post_path(@conn, :create) %>
 </section>

--- a/web/templates/shared/post.html.eex
+++ b/web/templates/shared/post.html.eex
@@ -22,6 +22,11 @@
           <li>
             <%= link("permalink", to: post_path(@conn, :show, @post), class: "post__permalink") %>
           </li>
+          <%= if @post.developer == Guardian.Plug.current_resource(@conn) do %>
+            <li>
+              <%= link("edit", to: post_path(@conn, :edit, @post), class: "post__permalink") %>
+            </li>
+          <% end %>
           <li>
             <%= link to: "#", class: "js-like-action post__like-link", id: @post.slug do %>
               <span class="post__like-count"><%= @post.likes %></span>


### PR DESCRIPTION
This completes the developer editing post story. 

I would have liked to pattern match the binary to the param directly for slug extraction, like:
```elixir
def show(conn, %{titled-slug => <<slug::size(10)-binary, _bla::binary>>}) do
  #all the things
end
```
However, this led to the scenario of "what happens when someone visits an invalid URL with less than 10 characters?". Now there wouldn't be a function that would match... So you would have to write catch alls for all actions you match the binary on (show, edit, update):

```elixir
def show(conn, _params) do
  #render 404
end
```
Thats a bummer. Assigning it to the conn doesn't feel too bad but I wish there was a better way. Maybe I'll think of something. 