### PR TITLE
Fix search

### DIFF
--- a/lib/tilex/posts.ex
+++ b/lib/tilex/posts.ex
@@ -11,17 +11,8 @@ defmodule Tilex.Posts do
   def by_channel(channel_name, page) do
     channel = Repo.get_by!(Channel, name: channel_name)
 
-    offset = (page - 1) * Application.get_env(:tilex, :page_size)
-    limit = Application.get_env(:tilex, :page_size) + 1
-
-    query = from p in Post,
-      order_by: [desc: p.inserted_at],
-      join: c in assoc(p, :channel),
-      join: d in assoc(p, :developer),
-      preload: [channel: c, developer: d],
-      limit: ^limit,
-      offset: ^offset,
-      where: p.channel_id == ^channel.id
+    query = posts(page)
+            |> where([p], p.channel_id == ^channel.id)
 
     posts_count = Repo.one(from p in "posts",
       where: p.channel_id == ^channel.id,
@@ -34,17 +25,8 @@ defmodule Tilex.Posts do
   def by_developer(username, page) do
     developer = Repo.get_by!(Developer, username: username)
 
-    offset = (page - 1) * Application.get_env(:tilex, :page_size)
-    limit = Application.get_env(:tilex, :page_size) + 1
-
-    query = from p in Post,
-      order_by: [desc: p.inserted_at],
-      join: c in assoc(p, :channel),
-      join: d in assoc(p, :developer),
-      preload: [channel: c, developer: d],
-      limit: ^limit,
-      offset: ^offset,
-      where: p.developer_id == ^developer.id
+    query = posts(page)
+            |> where([p], p.developer_id == ^developer.id)
 
     posts_count = Repo.one(from p in "posts",
       where: p.developer_id == ^developer.id,

--- a/test/features/visitor_searches_posts.exs
+++ b/test/features/visitor_searches_posts.exs
@@ -3,12 +3,12 @@ defmodule VisiorSearchesPosts do
 
   def fill_in_search(session, query) do
     visit(session, "/")
-    |> find(".site_nav__search .site_nav__link")
-    |> click()
+    |> find(Query.css(".site_nav__search .site_nav__link"))
+    |> Element.click()
 
-    fill_in(session, "query", with: query)
+    fill_in(session, Query.text_field("query"), with: query)
     |> take_screenshot
-    |> click_on("Search")
+    |> click(Query.button("Search"))
   end
 
   test "with no found posts", %{session: session} do
@@ -31,7 +31,7 @@ defmodule VisiorSearchesPosts do
     body = get_text(session, "body")
 
     assert search_result_header == "2 posts about rules"
-    assert find(session, "article.post", count: 2)
+    assert find(session, Query.css("article.post", [count: 2]))
     assert body =~ ~r/Elixir Rules/
     assert body =~ ~r/Hashrocket Rules/
     refute body =~ ~r/Because JavaScript/

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -3,6 +3,6 @@ defmodule Tilex.TestHelpers do
   use Wallaby.DSL
 
   def get_text(session, selector) do
-    session |> find(selector) |> text
+    session |> find(Query.css(selector)) |> Element.text
   end
 end

--- a/web/channels/post_channel.ex
+++ b/web/channels/post_channel.ex
@@ -16,6 +16,8 @@ defmodule Tilex.PostChannel do
     posts = Repo.all from p in Post,
       join: c in assoc(p, :channel),
       preload: [channel: c],
+      join: d in assoc(p, :developer),
+      preload: [developer: d],
       where: ilike(p.title, ^"%#{query}%")
 
       html = Phoenix.View.render_to_string(

--- a/web/templates/post/search_results.html.eex
+++ b/web/templates/post/search_results.html.eex
@@ -8,4 +8,6 @@
   </header>
 </section>
 
-<%= render Tilex.PostView, "index.html", conn: @conn, posts: @posts %>
+<section id="home">
+  <%= render Tilex.SharedView, "_posts_list.html", conn: @conn, posts: @posts %>
+</section>


### PR DESCRIPTION
I removed a lot of duplicate queries in `lib/tilex/posts.ex`, fixed some wallaby deprecations and fixed the search post feature.

TODO: Currently we can't paginate query responses because of a few reasons. 1 being that channels have no knowledge of conn. I think its an easy fix of just appending the page and query to the URL using the sockets response and then figuring out an elegant way to set `request_path` to the right URL for the `_pagination.html.eex` template. Either way searching currently works and pagination can be added at a later date. 