### PR TITLE
Make the wallaby package test only

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -56,7 +56,7 @@ defmodule Tilex.Mixfile do
       {:postgrex, ">= 0.0.0"},
       {:timex, "~> 3.0"},
       {:ueberauth_google, "~> 0.5"},
-      {:wallaby, "~> 0.17.0"},
+      {:wallaby, "~> 0.17.0", only: :test},
       {:extwitter, "~> 0.8"},
     ]
   end


### PR DESCRIPTION
I've experienced tons of PhantomJS processes getting spun up when running the development server. Adding the `only: test` to `wallaby` resolved this for me. Regardless, this should be a test-only dependency.