### PR TITLE
Add editor to developer form

### DIFF
--- a/priv/repo/migrations/20170602200233_add_editor_to_developers.exs
+++ b/priv/repo/migrations/20170602200233_add_editor_to_developers.exs
@@ -1,0 +1,9 @@
+defmodule Tilex.Repo.Migrations.AddEditorToDevelopers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:developers) do
+      add :editor, :string, default: "Text Field"
+    end
+  end
+end

--- a/test/features/developer_edits_profile_test.exs
+++ b/test/features/developer_edits_profile_test.exs
@@ -15,7 +15,6 @@ defmodule DeveloperEditsProfileTest do
     assert profile_form =~ "fine@sixdollareggs.com"
 
     session
-    |> fill_in(Query.text_field("Slack name"), with: "chriserin")
     |> fill_in(Query.text_field("Twitter handle"), with: "mcnormalmode")
     |> (fn(session) ->
       find(session, Query.select("Editor"), fn (element) ->
@@ -39,5 +38,6 @@ defmodule DeveloperEditsProfileTest do
                 |> hd
 
     assert developer.twitter_handle == "mcnormalmode"
+    assert developer.editor == "Ace"
   end
 end

--- a/web/models/developer.ex
+++ b/web/models/developer.ex
@@ -7,6 +7,7 @@ defmodule Tilex.Developer do
     field :google_id, :string
     field :twitter_handle, :string
     field :admin, :boolean
+    field :editor, :string
 
     has_many :posts, Tilex.Post
 
@@ -15,8 +16,8 @@ defmodule Tilex.Developer do
 
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:email, :username, :google_id, :twitter_handle])
-    |> validate_required([:email, :username, :google_id])
+    |> cast(params, [:email, :username, :google_id, :twitter_handle, :editor])
+    |> validate_required([:email, :username, :google_id, :editor])
   end
 
   def find_or_create(repo, attrs) do

--- a/web/templates/developer/edit.html.eex
+++ b/web/templates/developer/edit.html.eex
@@ -11,13 +11,6 @@
         </dt>
         <dd>
           <%= Guardian.Plug.current_resource(@conn).email %>
-       </dd>
-        <dt>
-          <%= label f, :slack_name %>
-          <%= error_tag f, :slack_name %>
-        </dt>
-        <dd>
-          <%= text_input f, :slack_name, placeholder: "Enter name..." %>
         </dd>
         <dt>
           <%= label f, :twitter_handle %>
@@ -31,7 +24,7 @@
           <%= error_tag f, :editor %>
         </dt>
         <dd>
-          <%= select f, :editor, ["Text Field", "Ace (w/ Vim)", "Ace"], prompt: "" %>
+          <%= select f, :editor, ["Text Field", "Ace (w/ Vim)", "Ace"] %>
         </dd>
       </dl>
       <%= submit "Submit" %>


### PR DESCRIPTION
Also cleans up Slack name concept, which we have decided to icebox for now.