### PR TITLE
Ensure auth on edit and update

### DIFF
--- a/web/controllers/post_controller.ex
+++ b/web/controllers/post_controller.ex
@@ -5,7 +5,7 @@ defmodule Tilex.PostController do
   plug :load_channels when action in [:new, :create, :edit, :update]
   plug :extract_slug when action in [:show, :edit, :update]
 
-  plug Guardian.Plug.EnsureAuthenticated, [handler: __MODULE__] when action in [:new, :create]
+  plug Guardian.Plug.EnsureAuthenticated, [handler: __MODULE__] when action in [:new, :create, :edit, :update]
 
   def unauthenticated(conn, _) do
     conn

--- a/web/models/developer.ex
+++ b/web/models/developer.ex
@@ -17,7 +17,7 @@ defmodule Tilex.Developer do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, [:email, :username, :google_id, :twitter_handle, :editor])
-    |> validate_required([:email, :username, :google_id, :editor])
+    |> validate_required([:email, :username, :google_id])
   end
 
   def find_or_create(repo, attrs) do


### PR DESCRIPTION
Going to the edit page when not authenticated caused a runtime exception instead of the expected response of going to index and displaying 'Authentication Required'.