### PR TITLE
Page title uses pattern matching

### DIFF
--- a/web/views/layout_view.ex
+++ b/web/views/layout_view.ex
@@ -1,15 +1,8 @@
 defmodule Tilex.LayoutView do
   use Tilex.Web, :view
 
-  def page_title(assigns) do
-    cond do
-      Map.get(assigns, :post) ->
-        " - #{assigns.post.title}"
-      Map.get(assigns, :channel) ->
-        " - ##{assigns.channel.name}"
-      Map.get(assigns, :developer) ->
-        " - #{assigns.developer.username}"
-      true -> ""
-    end
-  end
+  def page_title(%{post: post}), do: " - #{post.title}"
+  def page_title(%{channel: channel}), do: " - ##{channel.name}"
+  def page_title(%{developer: developer}), do: " - #{developer.username}"
+  def page_title(_), do: ""
 end


### PR DESCRIPTION
One of the things I discovered at ElixirConf EU is that Map lookups are fairly slow in Elixir (unexpected because in Ruby hash lookups are fairly fast). I don't feel like it decreases the readability of `page_title` and with some benchmarking using a large Map like assigns, the `Map.get` conditional would often be around ~2.9 timex slower: 

```
Name                     ips        average  deviation         median
page_title           25.01 M      0.0400 μs    ±44.55%      0.0400 μs
page_title_map        8.83 M       0.113 μs   ±161.15%       0.100 μs

Comparison:
page_title           25.01 M
page_title_map        8.83 M - 2.83x slower
```

```
Name                     ips        average  deviation         median
page_title           25.15 M      0.0398 μs    ±48.61%      0.0400 μs
page_title_map        8.62 M       0.116 μs   ±188.43%       0.100 μs

Comparison:
page_title           25.15 M
page_title_map        8.62 M - 2.92x slower
```