### PR TITLE
Remove #post_show id

### DIFF
--- a/test/features/visitor_searches_posts_test.exs
+++ b/test/features/visitor_searches_posts_test.exs
@@ -65,6 +65,6 @@ defmodule VisiorSearchesPosts do
   end
 
   defp get_first_post_on_page_title(session) do
-    get_text(session, "#home > #post_show:first-child h1 a")
+    get_text(session, "#home > section:first-child article.post h1 a")
   end
 end

--- a/test/support/pages/post_show_page.ex
+++ b/test/support/pages/post_show_page.ex
@@ -3,7 +3,7 @@ defmodule Tilex.Integration.Pages.PostShowPage do
 
   def ensure_page_loaded(session, post) do
     session
-    |> Browser.find(Query.css("#post_show"))
+    |> Browser.find(Query.css("article.post"))
 
     session
     |> Browser.find(Query.css("h1", text: post.title))

--- a/web/templates/shared/post.html.eex
+++ b/web/templates/shared/post.html.eex
@@ -1,4 +1,4 @@
-<section id="post_show">
+<section>
   <article class="post">
     <section>
       <div class="post__content copy">


### PR DESCRIPTION
Remove #post_show id.  This id was being repeated for each post on the screen.