### PR TITLE
Simplify page titles

### DIFF
--- a/test/features/visitor_views_channel_test.exs
+++ b/test/features/visitor_views_channel_test.exs
@@ -20,7 +20,7 @@ defmodule Features.VisitorViewsChannelTest do
 
     assert page_header =~ ~r/1 post about #phoenix/
     assert find(session, Query.css("article.post"))
-    assert page_title(session) == "Today I Learned - Hashrocket - #phoenix"
+    assert page_title(session) == "Phoenix - Today I Learned"
   end
 
   test "the page has a list of paginated posts", %{session: session} do

--- a/test/features/visitor_views_developer_test.exs
+++ b/test/features/visitor_views_developer_test.exs
@@ -15,7 +15,7 @@ defmodule Features.VisitorViewsDeveloper do
 
     assert page_header =~ ~r/1 post by makinpancakes/
     assert find(session, Query.css("article.post"))
-    assert page_title(session) == "Today I Learned - Hashrocket - makinpancakes"
+    assert page_title(session) == "makinpancakes - Today I Learned"
   end
 
   test "and sees a prolific developer's posts", %{session: session} do

--- a/test/features/visitor_views_post_test.exs
+++ b/test/features/visitor_views_post_test.exs
@@ -12,7 +12,7 @@ defmodule VisitorViewsPostTest do
 
     assert body =~ ~r/A special post/
     assert body =~ ~r/makinpancakes/
-    assert page_title(session) == "Today I Learned - Hashrocket - A special post"
+    assert page_title(session) == "A special post - Today I Learned"
   end
 
   test "and sees marketing copy, if it exists", %{session: session} do

--- a/web/controllers/stats_controller.ex
+++ b/web/controllers/stats_controller.ex
@@ -2,8 +2,8 @@ defmodule Tilex.StatsController do
   use Tilex.Web, :controller
 
   def index(conn, _params) do
-    render(
-           conn,
+    Plug.Conn.assign(conn, :page_title, "Statistics")
+    |> render(
            "index.html",
            Tilex.Stats.all
          )

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <title>
-      Today I Learned - <%= Application.get_env(:tilex, :organization_name) %><%= page_title(assigns) %>
+      <%= page_title(assigns) %> - Today I Learned
     </title>
 
     <meta name="csrf" content="<%= Plug.CSRFProtection.get_csrf_token() %>">

--- a/web/views/layout_view.ex
+++ b/web/views/layout_view.ex
@@ -1,8 +1,9 @@
 defmodule Tilex.LayoutView do
   use Tilex.Web, :view
 
-  def page_title(%{post: post}), do: " - #{post.title}"
-  def page_title(%{channel: channel}), do: " - ##{channel.name}"
-  def page_title(%{developer: developer}), do: " - #{developer.username}"
-  def page_title(_), do: ""
+  def page_title(%{post: post}), do: post.title
+  def page_title(%{channel: channel}), do: String.capitalize(channel.name)
+  def page_title(%{developer: developer}), do: developer.username
+  def page_title(%{page_title: page_title}), do: page_title
+  def page_title(_), do: Application.get_env(:tilex, :organization_name)
 end


### PR DESCRIPTION
Page Titles are a significant SEO factor.  We had included the
organization name "Hashrocket" into the page title to try to
differentiate our "Today I Learned" site from the others, but this
was an experiment rather than a solution.  With the tilex deployment
it was likely the wrong time to make that experiment.

In addition, according to the search console help:

https://support.google.com/webmasters/answer/35624?visit_id=1-636351220308427108-3910826740&rd=1

Branding is encouraged but boilerplate is discouraged.  It's unclear if
the Hashrocket part of "Today I Learned - Hashrocket" would be
interpreted as branding or as something different.

Conciseness is encouraged as well, therefore this commit reverts to a
page title style that is simpler and more like what we had previously in
the Rails version.