### PR TITLE
Links use full post slug from stats page

### DIFF
--- a/web/controllers/stats_controller.ex
+++ b/web/controllers/stats_controller.ex
@@ -2,10 +2,8 @@ defmodule Tilex.StatsController do
   use Tilex.Web, :controller
 
   def index(conn, _params) do
-    Plug.Conn.assign(conn, :page_title, "Statistics")
-    |> render(
-           "index.html",
-           Tilex.Stats.all
-         )
+    conn
+    |> assign(:page_title, "Statistics")
+    |> render("index.html", Tilex.Stats.all)
   end
 end

--- a/web/templates/stats/index.html.eex
+++ b/web/templates/stats/index.html.eex
@@ -22,7 +22,8 @@
       <ul class="post_list">
         <%= for {post_title, post_likes, post_slug, channel_name, _score} <- @hottest_posts do %>
           <li>
-            <a href="/posts/<%= post_slug %>"><b>
+            <%= link(to: post_path(@conn, :show, %Tilex.Post{slug: post_slug, title: post_title})) do %>
+              <b>
                 <%= post_title %>
               </b>
               <small>
@@ -30,7 +31,7 @@
                 <span>•</span>
                 <%= post_likes %> likes
               </small>
-            </a>
+            <% end %>
           </li>
         <% end %>
       </ul>
@@ -42,7 +43,8 @@
       <ul class="post_list">
         <%= for {post_title, post_likes, post_slug, channel_name} <- @most_liked_posts do %>
           <li>
-            <a href="/posts/<%= post_slug %>"><b>
+            <%= link(to: post_path(@conn, :show, %Tilex.Post{slug: post_slug, title: post_title})) do %>
+              <b>
                 <%= post_title %>
               </b>
               <small>
@@ -50,7 +52,7 @@
                 <span>•</span>
                 <%= post_likes %> likes
               </small>
-            </a>
+            <% end %>
           </li>
         <% end %>
       </ul>


### PR DESCRIPTION
Links now use the full sluggified URL

Fixes #87 