### PR TITLE
Auto resize post form body

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "watch": "brunch watch --stdin"
   },
   "dependencies": {
+    "autosize": "^4.0.0",
     "jquery": ">= 2.1",
     "jquery.cookie": "^1.4.1",
     "phoenix": "file:deps/phoenix",

--- a/web/static/js/post_form.js
+++ b/web/static/js/post_form.js
@@ -1,4 +1,5 @@
 import TextConversion from './text_conversion';
+import autosize from 'autosize';
 
 export default class PostForm {
   constructor(properties) {
@@ -24,6 +25,7 @@ export default class PostForm {
     this.setInitialPreview();
     this.observePostBodyInputChange();
     this.observeTitleInputChange();
+    autosize(this.$postBodyInput);
   }
 
   setInitialPreview() {


### PR DESCRIPTION
Fixes #65 

It should now auto-expand (similar to how hr-til worked). I didn't check in the `/priv/static/*` files that will need to be included due to https://github.com/hashrocket/tilex/commit/39fad765a21b25bba282b07691a14f9a3eef91d5 . I'm using NPM version 3.10.10 and there were other changes made in some of the other js files probably due to differing versions? 

@jwworth How should I handle this? Should I just check in the `/priv` files my version spits out?