### PR TITLE
Developer post api

### DIFF
--- a/web/controllers/api/developer_post_controller.ex
+++ b/web/controllers/api/developer_post_controller.ex
@@ -1,8 +1,6 @@
 defmodule Tilex.Api.DeveloperPostController do
   use Tilex.Web, :controller
 
-  alias Tilex.Post
-
   def index(conn, params) do
     posts = Tilex.Posts.by_developer(params["username"], limit: 3)
 

--- a/web/controllers/api/developer_post_controller.ex
+++ b/web/controllers/api/developer_post_controller.ex
@@ -4,6 +4,6 @@ defmodule Tilex.Api.DeveloperPostController do
   def index(conn, params) do
     posts = Tilex.Posts.by_developer(params["username"], limit: 3)
 
-    render conn, "index.json", posts: posts
+    render(conn, "index.json", posts: posts)
   end
 end

--- a/web/views/api/developer_post_view.ex
+++ b/web/views/api/developer_post_view.ex
@@ -4,15 +4,8 @@ defmodule Tilex.Api.DeveloperPostView do
   def render("index.json", %{posts: posts}) do
     %{
       data: %{
-        posts: Enum.map(posts, &post_json/1)
+        posts: render_many(posts, Tilex.Api.PostView, "post.json")
       }
-    }
-  end
-
-  def post_json(post) do
-    %{
-      slug: post.slug,
-      title: post.title,
     }
   end
 end

--- a/web/views/api/post_view.ex
+++ b/web/views/api/post_view.ex
@@ -1,0 +1,5 @@
+defmodule Tilex.Api.PostView do
+  use Tilex.Web, :view
+
+  def render("post.json", %{post: post}), do: Map.take(post, [:slug, :title])
+end


### PR DESCRIPTION
I noticed we had a warning:

```terminal
warning: unused alias Post
  web/controllers/api/developer_post_controller.ex:4
```
So I removed that. 

I also changed how we render the post JSON to use the more standard Phoenix convention of `render_many/3`. Open to suggestions but that seems to be the way most Phoenix apps are doing it. 