### PR TITLE
Remove hardcoded url from twitter card endpoint

### DIFF
--- a/lib/tilex/web/templates/layout/app.html.eex
+++ b/lib/tilex/web/templates/layout/app.html.eex
@@ -21,7 +21,7 @@
     <meta name="twitter:creator" content="@hashrockettil">
     <meta name="twitter:title" content="Today I Learned: a Hashrocket Project">
     <meta name="twitter:description" content="TIL is an open-source project by Hashrocket that exists to catalogue the sharing & accumulation of knowledge as it happens day-to-day. Posts have a 200-word limit, and posting is open to any Rocketeer as well as select friends of the team. We hope you enjoy learning along with us.">
-    <meta name="twitter:image" content="https://til.hashrocket.com/assets/til_twittercard.png">
+    <meta name="twitter:image" content=<%= Tilex.Web.Endpoint.static_url() <> "/assets/til_twittercard.png" %>>
 
     <link href='//fonts.googleapis.com/css?family=Raleway:700,900' rel='stylesheet' type='text/css'>
     <link href='//fonts.googleapis.com/css?family=Lora:400,700italic,700,400italic' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
I had left the hardcoded "https://til.hashrocket.com" in the twittercard.png URL because I didn't want to risk breaking anything with adding `/priv/ static` back to the .gitignore. However that all seems to be working so this is the logical next step.