### PR TITLE
Fix warnings

### DIFF
--- a/lib/tilex/integrations.ex
+++ b/lib/tilex/integrations.ex
@@ -15,6 +15,7 @@ defmodule Tilex.Integrations do
 
     conn
   end
+  def notify(conn, _), do: conn
 
   def notify_of_awards(post = %Tilex.Post{max_likes: max_likes}, max_likes_changed) when rem(max_likes, 10) == 0 and max_likes_changed do
     developer = Tilex.Repo.one(Ecto.assoc(post, :developer))
@@ -23,8 +24,4 @@ defmodule Tilex.Integrations do
     @slack_notifier.notify_of_awards(post, developer, url)
   end
   def notify_of_awards(_, _), do: nil
-
-  def notify(conn, _) do
-    conn
-  end
 end

--- a/lib/tilex/integrations.ex
+++ b/lib/tilex/integrations.ex
@@ -18,7 +18,7 @@ defmodule Tilex.Integrations do
 
   def notify_of_awards(post = %Tilex.Post{max_likes: max_likes}, max_likes_changed) when rem(max_likes, 10) == 0 and max_likes_changed do
     developer = Tilex.Repo.one(Ecto.assoc(post, :developer))
-    url = Tilex.Router.Helpers.post_url(Tilex.Endpoint, :show, post)
+    url = Tilex.Web.Router.Helpers.post_url(Tilex.Endpoint, :show, post)
 
     @slack_notifier.notify_of_awards(post, developer, url)
   end

--- a/lib/tilex/slack.ex
+++ b/lib/tilex/slack.ex
@@ -4,7 +4,7 @@ defmodule Tilex.Slack do
     |> send_slack_message
   end
 
-  def notify_of_awards(post = %Tilex.Post{max_likes: max_likes, title: title}, developer, url) do
+  def notify_of_awards(%Tilex.Post{max_likes: max_likes, title: title}, developer, url) do
     appropriate_emoji = [ "🎉", "🎂", "✨", "💥", "❤️", "🎈", "👑", "🎓", "🏆", "💯 "]
                         |> Enum.at(round((max_likes / 10) - 1), "😀")
 

--- a/lib/tilex/web/templates/shared/post.html.eex
+++ b/lib/tilex/web/templates/shared/post.html.eex
@@ -16,7 +16,7 @@
              data-url= "<%= post_url(@conn, :show, @post) %>">
             Tweet
           </a>
-        <%= end %>
+        <% end %>
 
         <footer>
           <p>

--- a/test/features/developer_creates_post_test.exs
+++ b/test/features/developer_creates_post_test.exs
@@ -9,8 +9,6 @@ defmodule DeveloperCreatesPostTest do
     PostForm
   }
 
-  alias Tilex.Web.Endpoint
-
   test "fills out form and submits", %{session: session} do
     Factory.insert!(:channel, name: "phoenix")
     developer = Factory.insert!(:developer)


### PR DESCRIPTION
Fixing some random warnings and deprecations:

```
warning: variable "post" is unused
  lib/tilex/slack.ex:7

warning: clauses for the same def should be grouped together, def notify/2 was previously defined (lib/tilex/integrations.ex:5)
  lib/tilex/integrations.ex:27

warning: unexpected beginning of EEx tag "<%=" on end of expression "<%= end %>", please remove "=" accordingly
  lib/tilex/web/templates/shared/post.html.eex:19

warning: function Tilex.Router.Helpers.post_url/3 is undefined (module Tilex.Router.Helpers is not available)
  lib/tilex/integrations.ex:21

19:29:45.050 [warn] Warning: No valid AppSignal configuration found, continuing with AppSignal metrics disabled.
warning: unused alias Endpoint
  test/features/developer_creates_post_test.exs:12
```
