### PR TITLE
Extend HTTPoison timeout in test

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -59,5 +59,3 @@ config :extwitter, :oauth, [
    access_token: System.get_env("twitter_access_token"),
    access_token_secret: System.get_env("twitter_access_token_secret")
 ]
-
-config :httpoison, timeout: 6000

--- a/config/test.exs
+++ b/config/test.exs
@@ -29,3 +29,5 @@ config :tilex, :canonical_domain, "https://til.hashrocket.com"
 config :tilex, :default_twitter_handle, "hashrocket"
 
 config :tilex, :async_feature_test, (System.get_env("ASYNC_FEATURE_TEST") == "yes")
+
+config :httpoison, timeout: 6000


### PR DESCRIPTION
This moves a timeout extension I added to fix a broken build from all configuration to just the test environment.