### PR TITLE
Add author/creator to rss feed

### DIFF
--- a/lib/tilex/web/templates/feed/index.xml.eex
+++ b/lib/tilex/web/templates/feed/index.xml.eex
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Today I Learned</title>
-    <description>TIL is an open-source project by Hashrocket that exists to catalogue the sharing &amp; accumulation of knowledge as it happens day-to-day.
+    <description>TIL is an open-source project by Hashrocket that exists to catalogue the sharing and accumulation of knowledge as it happens day-to-day.
     </description>
     <link><%= post_url(@conn, :index) %></link>
     <atom:link href="https://til.hashrocket.com/rss" rel="self" type="application/rss+xml" />
@@ -15,6 +15,9 @@
         <description>
           <![CDATA[<%= Tilex.Markdown.to_html(post.body) %>]]>
         </description>
+        <dc:creator>
+          <%= post.developer.username %>
+        </dc:creator>
         <pubDate><%= Tilex.Web.SharedView.rss_date(post) %></pubDate>
         <guid isPermaLink="true"><%= post_url(@conn, :show, post) %></guid>
       </item>


### PR DESCRIPTION
I started using [Reeder](http://reederapp.com/mac/) and noticed you didn't have an author tag.  Finally had an excuse to contribute 😄 .

Atom specification requires email addresses to be supplied when
using `<author>`. Use Dublin Core `<dc:creator>` instead. Replace
`&` with `and` for proper rss validation.

If you don't mind having your email addresses in the rss feed we can use:
```
<author>
  <name> <%= post.developer.name %> </name>
  <email> <%= post.developer.email %> </email>
</author>
```

I'm assuming name and email exist due to their presence in `validate_required`.