### PR TITLE
Require canonical domain for Heroku review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,6 +10,9 @@
     "BASIC_AUTH_USERNAME": {
       "required": true
     },
+    "CANONICAL_DOMAIN": {
+      "required": true
+    },
     "ENABLE_BASIC_AUTH": {
       "required": true
     },


### PR DESCRIPTION
Currently the review apps post show pages are broken. They blow up because they are missing the Canonical Domain. 