### PR TITLE
Import global iex config when available

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,3 +1,5 @@
+import_file_if_available("~/.iex.exs")
+
 alias Tilex.{
   Channel,
   Developer,


### PR DESCRIPTION
#135 overrides a users global iex configuration, which is the fallback if a local one doesn't exist. This imports that file if it exists so that we can still have our global settings. 