### PR TITLE
Document ChromeDriver as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ user on subsequent authentications.
 
 ### Testing
 
-Wallaby relies on PhantomJS; install it:
+Wallaby relies on ChromeDriver; install it (OSX):
 
 ```
-$ npm install -g phantomjs
+$ brew install chromedriver
 ```
 
 Run the tests with:


### PR DESCRIPTION
Running the tests without ChromeDriver resulted in an error that included:

```
"Looks like you're trying to run an older version of chromedriver. Wallaby needs at least chromedriver 2.30 to run correctly.
```

This fixes that error.