### PR TITLE
Document all Tilex modules

### DIFF
--- a/lib/guardian_serializer.ex
+++ b/lib/guardian_serializer.ex
@@ -1,8 +1,7 @@
 defmodule Tilex.GuardianSerializer do
   @behaviour Guardian.Serializer
 
-  alias Tilex.Repo
-  alias Tilex.Developer
+  alias Tilex.{Developer, Repo}
 
   def for_token(developer = %Developer{}), do: { :ok, "Developer:#{developer.id}" }
   def for_token(_), do: { :error, "Unknown resource type" }

--- a/lib/guardian_serializer.ex
+++ b/lib/guardian_serializer.ex
@@ -1,4 +1,9 @@
 defmodule Tilex.GuardianSerializer do
+
+  @moduledoc """
+    Provides functions for managing sessions with Guardian.
+  """
+
   @behaviour Guardian.Serializer
 
   alias Tilex.{Developer, Repo}

--- a/lib/test/slack.ex
+++ b/lib/test/slack.ex
@@ -1,4 +1,9 @@
 defmodule Test.Slack do
+
+  @moduledoc """
+    Mocks Slack functions for testing.
+  """
+
   def notify(_post, _developer, _channel, _url) do
     :ok
   end

--- a/lib/test/twitter.ex
+++ b/lib/test/twitter.ex
@@ -1,4 +1,9 @@
 defmodule Test.Twitter do
+
+  @moduledoc """
+    Mocks Twitter functions for testing.
+  """
+
   def notify(_post, _developer, _channel, _url) do
     :ok
   end

--- a/lib/tilex.ex
+++ b/lib/tilex.ex
@@ -1,4 +1,9 @@
 defmodule Tilex do
+
+  @moduledoc """
+    Defines the Tilex application.
+  """
+
   use Application
 
   # See http://elixir-lang.org/docs/stable/elixir/Application.html

--- a/lib/tilex/cache.ex
+++ b/lib/tilex/cache.ex
@@ -1,4 +1,9 @@
 defmodule Tilex.Cache do
+
+  @moduledoc """
+    Caches markdown conversion to HTML.
+  """
+
   def cache(key, value_block) do
     Cachex.get(:tilex_cache, key)
     |> process_cache(key, value_block)

--- a/lib/tilex/cache.ex
+++ b/lib/tilex/cache.ex
@@ -4,7 +4,7 @@ defmodule Tilex.Cache do
     |> process_cache(key, value_block)
   end
 
-  defp process_cache({:ok, value}, _,_), do: value
+  defp process_cache({:ok, value}, _, _), do: value
 
   defp process_cache({:missing, _}, key, value_block) do
     value = value_block.()

--- a/lib/tilex/integrations.ex
+++ b/lib/tilex/integrations.ex
@@ -1,4 +1,9 @@
 defmodule Tilex.Integrations do
+
+  @moduledoc """
+    Integrates Twitter and Slack into Tilex.
+  """
+
   @slack_notifier Application.get_env(:tilex, :slack_notifier)
   @twitter_notifier Application.get_env(:tilex, :twitter_notifier)
 

--- a/lib/tilex/liking.ex
+++ b/lib/tilex/liking.ex
@@ -1,4 +1,9 @@
 defmodule Tilex.Liking do
+
+  @moduledoc """
+    Provides functions for liking and unliking a post.
+  """
+
   def like(slug) do
     post = Tilex.Repo.get_by!(Tilex.Post, slug: slug)
     likes = post.likes + 1

--- a/lib/tilex/markdown.ex
+++ b/lib/tilex/markdown.ex
@@ -1,4 +1,9 @@
 defmodule Tilex.Markdown do
+
+  @moduledoc """
+    Provides support for rendering Markdown.
+  """
+
   def to_html_live(markdown) do
     markdown
     |> Earmark.as_html!

--- a/lib/tilex/plug/basic_auth.ex
+++ b/lib/tilex/plug/basic_auth.ex
@@ -1,4 +1,9 @@
 defmodule Tilex.Plug.BasicAuth do
+
+  @moduledoc """
+    Provides basic authentication for staging instances.
+  """
+
   def init(default), do: default
 
   def call(conn, _default) do

--- a/lib/tilex/posts.ex
+++ b/lib/tilex/posts.ex
@@ -1,4 +1,9 @@
 defmodule Tilex.Posts do
+
+  @moduledoc """
+    Provides query functions for retrieving posts and associated data.
+  """
+
   import Ecto.Query
 
   alias Tilex.{Channel, Developer, Post, Repo}

--- a/lib/tilex/repo.ex
+++ b/lib/tilex/repo.ex
@@ -1,3 +1,8 @@
 defmodule Tilex.Repo do
+
+  @moduledoc """
+    Provides the Ecto repository to wrap our data store.
+  """
+
   use Ecto.Repo, otp_app: :tilex
 end

--- a/lib/tilex/slack.ex
+++ b/lib/tilex/slack.ex
@@ -1,4 +1,9 @@
 defmodule Tilex.Slack do
+
+  @moduledoc """
+    Provides functions for posting to Slack.
+  """
+
   def notify(post, developer, channel, url) do
     "#{developer.username} created a new post <#{url}|#{post.title}> ##{channel.name}"
     |> send_slack_message

--- a/lib/tilex/stats.ex
+++ b/lib/tilex/stats.ex
@@ -1,4 +1,9 @@
 defmodule Tilex.Stats do
+
+  @moduledoc """
+    Provides functions for querying statistics data.
+  """
+
   import Ecto.Query
 
   alias Tilex.Repo

--- a/lib/tilex/twitter.ex
+++ b/lib/tilex/twitter.ex
@@ -1,4 +1,9 @@
 defmodule Tilex.Twitter do
+
+  @moduledoc """
+    Provides functions for posting to Twitter.
+  """
+
   def notify(post, developer, channel, url) do
     "#{post.title} #{url} via @#{Tilex.Developer.twitter_handle(developer)} #til ##{channel.twitter_hashtag}"
     |> send_tweet

--- a/lib/tilex_web/channels/text_converter_channel.ex
+++ b/lib/tilex_web/channels/text_converter_channel.ex
@@ -1,4 +1,9 @@
 defmodule Tilex.TextConverterChannel do
+
+  @moduledoc """
+    Allows developers to view a post body preview.
+  """
+
   use Phoenix.Channel
 
   def join("text_converter", _message, socket) do

--- a/lib/tilex_web/channels/user_socket.ex
+++ b/lib/tilex_web/channels/user_socket.ex
@@ -1,4 +1,9 @@
 defmodule TilexWeb.UserSocket do
+
+  @moduledoc """
+    Defines channels for searching and previewing posts.
+  """
+
   use Phoenix.Socket
 
   ## Channels

--- a/lib/tilex_web/controllers/api/developer_post_controller.ex
+++ b/lib/tilex_web/controllers/api/developer_post_controller.ex
@@ -1,4 +1,9 @@
 defmodule TilexWeb.Api.DeveloperPostController do
+
+  @moduledoc """
+    Provides an API endpoint for querying a developer's three latest posts.
+  """
+
   use TilexWeb, :controller
 
   def index(conn, params) do

--- a/lib/tilex_web/controllers/auth_controller.ex
+++ b/lib/tilex_web/controllers/auth_controller.ex
@@ -1,4 +1,9 @@
 defmodule TilexWeb.AuthController do
+
+  @moduledoc """
+    Provides functions to support Google OAuth and authentication.
+  """
+
   use TilexWeb, :controller
   plug Ueberauth
 

--- a/lib/tilex_web/controllers/channel_controller.ex
+++ b/lib/tilex_web/controllers/channel_controller.ex
@@ -1,4 +1,9 @@
 defmodule TilexWeb.ChannelController do
+
+  @moduledoc """
+    Provides a function to query posts by channel.
+  """
+
   use TilexWeb, :controller
 
   def show(conn, %{"name" => channel_name} = params) do

--- a/lib/tilex_web/controllers/developer_controller.ex
+++ b/lib/tilex_web/controllers/developer_controller.ex
@@ -1,4 +1,9 @@
 defmodule TilexWeb.DeveloperController do
+
+  @moduledoc """
+    Provides functions to manage developers.
+  """
+
   use TilexWeb, :controller
 
   alias Tilex.Developer

--- a/lib/tilex_web/controllers/feed_controller.ex
+++ b/lib/tilex_web/controllers/feed_controller.ex
@@ -1,4 +1,9 @@
 defmodule TilexWeb.FeedController do
+
+  @moduledoc """
+    Provides a function to display an RSS feed.
+  """
+
   use TilexWeb, :controller
 
   def index(conn, _params) do

--- a/lib/tilex_web/controllers/post_controller.ex
+++ b/lib/tilex_web/controllers/post_controller.ex
@@ -1,4 +1,9 @@
 defmodule TilexWeb.PostController do
+
+  @moduledoc """
+    Provides functions to manage posts.
+  """
+
   use TilexWeb, :controller
   import Ecto.Query
 

--- a/lib/tilex_web/controllers/sitemap_controller.ex
+++ b/lib/tilex_web/controllers/sitemap_controller.ex
@@ -1,4 +1,9 @@
 defmodule TilexWeb.SitemapController do
+
+  @moduledoc """
+    Provides a function to display a sitemap.
+  """
+
   use TilexWeb, :controller
 
   def index(conn, _) do

--- a/lib/tilex_web/controllers/stats_controller.ex
+++ b/lib/tilex_web/controllers/stats_controller.ex
@@ -1,4 +1,9 @@
 defmodule TilexWeb.StatsController do
+
+  @moduledoc """
+    Provides support for Tilex statistics.
+  """
+
   use TilexWeb, :controller
 
   def index(conn, _params) do

--- a/lib/tilex_web/controllers/test/auth_controller.ex
+++ b/lib/tilex_web/controllers/test/auth_controller.ex
@@ -1,7 +1,7 @@
 defmodule TilexWeb.Test.AuthController do
 
   @moduledoc """
-    Provides support for Tilex statistics.
+    Provides support for Tilex Authentication.
   """
 
   use TilexWeb, :controller

--- a/lib/tilex_web/controllers/test/auth_controller.ex
+++ b/lib/tilex_web/controllers/test/auth_controller.ex
@@ -1,4 +1,9 @@
 defmodule TilexWeb.Test.AuthController do
+
+  @moduledoc """
+    Provides support for Tilex statistics.
+  """
+
   use TilexWeb, :controller
 
   def index(conn, params) do

--- a/lib/tilex_web/endpoint.ex
+++ b/lib/tilex_web/endpoint.ex
@@ -1,4 +1,9 @@
 defmodule TilexWeb.Endpoint do
+
+  @moduledoc """
+    Defines Tilex's Phoenix endpoint.
+  """
+
   use Phoenix.Endpoint, otp_app: :tilex
 
   if Application.get_env(:tilex, :sql_sandbox) do

--- a/lib/tilex_web/gettext.ex
+++ b/lib/tilex_web/gettext.ex
@@ -1,4 +1,5 @@
 defmodule TilexWeb.Gettext do
+
   @moduledoc """
   A module providing Internationalization with a gettext-based API.
 
@@ -20,5 +21,6 @@ defmodule TilexWeb.Gettext do
 
   See the [Gettext Docs](https://hexdocs.pm/gettext) for detailed usage.
   """
+
   use Gettext, otp_app: :tilex
 end

--- a/lib/tilex_web/models/channel.ex
+++ b/lib/tilex_web/models/channel.ex
@@ -1,4 +1,9 @@
 defmodule Tilex.Channel do
+
+  @moduledoc """
+    Defines Tilex's Phoenix channel.
+  """
+
   use TilexWeb, :model
 
   schema "channels" do

--- a/lib/tilex_web/models/developer.ex
+++ b/lib/tilex_web/models/developer.ex
@@ -1,4 +1,9 @@
 defmodule Tilex.Developer do
+
+  @moduledoc """
+    Defines the developer model.
+  """
+
   use TilexWeb, :model
 
   schema "developers" do

--- a/lib/tilex_web/models/post.ex
+++ b/lib/tilex_web/models/post.ex
@@ -1,4 +1,9 @@
 defmodule Tilex.Post do
+
+  @moduledoc """
+    Defines the post model.
+  """
+
   use TilexWeb, :model
 
   @body_max_words 200

--- a/lib/tilex_web/router.ex
+++ b/lib/tilex_web/router.ex
@@ -1,4 +1,9 @@
 defmodule TilexWeb.Router do
+
+  @moduledoc """
+    Defines Tilex's Phoenix router.
+  """
+
   use TilexWeb, :router
 
   @auth_controller Application.get_env(:tilex, :auth_controller)


### PR DESCRIPTION
Tilex should serve as an example of exemplary Elixir code, so I think
adding moduledocs makes sense. This fixes all 'readability' concerns, as defined by credo.

I see these as a starting point to a larger conversation about what
each module does and its function with respect to the application.