### PR TITLE
Increase cookie size to 8192 from default of 4096

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -15,7 +15,8 @@ config :tilex, TilexWeb.Endpoint,
   secret_key_base: "mdTtrt4Y4JrtiTv63NepUe4fs1iSt23VfzKpnXm6mawKl6wN8jEfLfIf2HbyMeKe",
   render_errors: [view: TilexWeb.ErrorView, accepts: ~w(html json)],
   pubsub: [name: Tilex.PubSub,
-           adapter: Phoenix.PubSub.PG2]
+           adapter: Phoenix.PubSub.PG2],
+  http: [protocol_options: [max_request_line_length: 8192, max_header_value_length: 8192]]
 
 # Configures Elixir's Logger
 config :logger, :console,


### PR DESCRIPTION
Currently, likes are stored as cookies.  All the cookies are
collectively submitted as one http header.  Once you've made ~162 likes
then the header size for those cookies exceeds the max header size
allowed on the server.  This is also reportedly an issue in some
browsers but has not been encountered.  Chrome and Firefox handle large
headers fine.  Untested on IE.

For now up the header size allowed on the server to 8192.