### PR TITLE
Developer selects Code Editor / Vim

### DIFF
--- a/assets/brunch-config.js
+++ b/assets/brunch-config.js
@@ -20,7 +20,7 @@ exports.config = {
       // }
     },
     stylesheets: {
-      joinTo: "css/app.css",
+      joinTo: 'css/app.css',
       order: {
         after: ["web/static/css/app.css"] // concat app.css last
       }
@@ -54,7 +54,7 @@ exports.config = {
     },
     sass: {
       mode: "native"
-    }
+    },
   },
 
   modules: {
@@ -64,6 +64,9 @@ exports.config = {
   },
 
   npm: {
+    styles: {
+      codemirror: ['lib/codemirror.css','theme/dracula.css']
+    },
     enabled: true,
     globals: {
       $: 'jquery',

--- a/assets/css/_components.sass
+++ b/assets/css/_components.sass
@@ -194,6 +194,8 @@ form
     display: inline
     color: $error
     font-size: .85em
+  .CodeMirror
+    font-size: 2rem
   label
     font-weight: bold
     &.checkbox

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -1228,6 +1228,19 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
+    "codemirror": {
+      "version": "5.28.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.28.0.tgz",
+      "integrity": "sha512-E/Z6050shti9v9ivl0dUClVRM4xaH204jsJmEpNYC6KDTlQwAz+5DdhLzn0tjaL/Mp1P0J1uhZokcSP2RFSwlA=="
+    },
+    "codemirror-mode-elixir": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/codemirror-mode-elixir/-/codemirror-mode-elixir-1.1.1.tgz",
+      "integrity": "sha1-zFt5v1+TttpCbjI2Smc6aBORQWw=",
+      "requires": {
+        "codemirror": "5.28.0"
+      }
+    },
     "coffee-script": {
       "version": "1.12.7",
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",

--- a/assets/package.json
+++ b/assets/package.json
@@ -7,6 +7,8 @@
   },
   "dependencies": {
     "autosize": "^4.0.0",
+    "codemirror": "^5.28.0",
+    "codemirror-mode-elixir": "^1.1.1",
     "jquery": ">= 2.1",
     "jquery.cookie": "^1.4.1",
     "phoenix": "file:../deps/phoenix",

--- a/lib/tilex_web/controllers/post_controller.ex
+++ b/lib/tilex_web/controllers/post_controller.ex
@@ -68,8 +68,13 @@ defmodule TilexWeb.PostController do
   end
 
   def new(conn, _params) do
+    current_user = Guardian.Plug.current_resource(conn)
     changeset = Post.changeset(%Post{})
-    render conn, "new.html", changeset: changeset
+
+    conn
+    |> assign(:changeset, changeset)
+    |> assign(:current_user, current_user)
+    |> render("new.html")
   end
 
   def like(conn, %{"slug" => slug}) do
@@ -104,7 +109,10 @@ defmodule TilexWeb.PostController do
         |> Tilex.Integrations.notify(post)
 
       {:error, changeset} ->
-        render(conn, "new.html", changeset: changeset)
+        conn
+        |> assign(:current_user, developer)
+        |> assign(:changeset, changeset)
+        |> render("new.html")
     end
   end
 
@@ -120,7 +128,11 @@ defmodule TilexWeb.PostController do
 
     changeset = Post.changeset(post)
 
-    render(conn, "edit.html", post: post, changeset: changeset)
+    conn
+    |> assign(:post, post)
+    |> assign(:changeset, changeset)
+    |> assign(:current_user, current_user)
+    |> render("edit.html")
   end
 
   def update(conn, %{"post" => post_params}) do

--- a/lib/tilex_web/templates/developer/edit.html.eex
+++ b/lib/tilex_web/templates/developer/edit.html.eex
@@ -24,7 +24,7 @@
           <%= error_tag f, :editor %>
         </dt>
         <dd>
-          <%= select f, :editor, ["Text Field", "Ace (w/ Vim)", "Ace"] %>
+          <%= select f, :editor, ["Text Field", "Vim", "Code Editor"] %>
         </dd>
       </dl>
       <%= submit "Submit" %>

--- a/lib/tilex_web/templates/post/edit.html.eex
+++ b/lib/tilex_web/templates/post/edit.html.eex
@@ -2,5 +2,5 @@
   <header class='page_head'>
     <h1>Edit Post</h1>
   </header>
-  <%= render TilexWeb.PostView, "form.html", channels: @channels, changeset: @changeset, action: post_path(@conn, :update, @post) %>
+  <%= render TilexWeb.PostView, "form.html", channels: @channels, changeset: @changeset, current_user: @current_user, action: post_path(@conn, :update, @post) %>
 </section>

--- a/lib/tilex_web/templates/post/form.html.eex
+++ b/lib/tilex_web/templates/post/form.html.eex
@@ -46,3 +46,8 @@
     </div>
   </section>
 </article>
+
+<script type="text/javascript">
+  var TIL = TIL || {};
+  TIL.editor = '<%= @current_user.editor %>';
+</script>

--- a/lib/tilex_web/templates/post/new.html.eex
+++ b/lib/tilex_web/templates/post/new.html.eex
@@ -2,5 +2,5 @@
   <header class='page_head'>
     <h1>Create Post</h1>
   </header>
-  <%= render TilexWeb.PostView, "form.html", channels: @channels, changeset: @changeset, action: post_path(@conn, :create) %>
+  <%= render TilexWeb.PostView, "form.html", channels: @channels, changeset: @changeset, current_user: @current_user, action: post_path(@conn, :create) %>
 </section>

--- a/priv/repo/migrations/20170823194255_update_text_editor_on_developers.exs
+++ b/priv/repo/migrations/20170823194255_update_text_editor_on_developers.exs
@@ -1,0 +1,23 @@
+defmodule Tilex.Repo.Migrations.UpdateTextEditorOnDevelopers do
+  use Ecto.Migration
+
+  def up do
+    execute """
+    update developers set editor = 'Vim' where editor = 'Ace (w/ Vim)';
+    """
+
+    execute """
+    update developers set editor = 'Code Editor' where editor = 'Ace';
+    """
+  end
+
+  def down do
+    execute """
+    update developers set editor = 'Ace (w/ Vim)' where editor = 'Vim';
+    """
+
+    execute """
+    update developers set editor = 'Ace' where editor = 'Code Editor';
+    """
+  end
+end

--- a/test/features/developer_edits_profile_test.exs
+++ b/test/features/developer_edits_profile_test.exs
@@ -18,7 +18,7 @@ defmodule DeveloperEditsProfileTest do
     |> fill_in(Query.text_field("Twitter handle"), with: "mcnormalmode")
     |> (fn(session) ->
       find(session, Query.select("Editor"), fn (element) ->
-        click(element, Query.option("Ace"))
+        click(element, Query.option("Vim"))
       end)
       session
     end).()
@@ -38,6 +38,6 @@ defmodule DeveloperEditsProfileTest do
                 |> hd
 
     assert developer.twitter_handle == "mcnormalmode"
-    assert developer.editor == "Ace"
+    assert developer.editor == "Vim"
   end
 end

--- a/test/features/visitor_searches_posts_test.exs
+++ b/test/features/visitor_searches_posts_test.exs
@@ -7,7 +7,6 @@ defmodule VisiorSearchesPosts do
     |> Element.click()
 
     fill_in(session, Query.text_field("q"), with: query)
-    |> take_screenshot
     |> click(Query.button("Search"))
   end
 


### PR DESCRIPTION
Closes #68 

The name of the branch is a bit misleading as we are now using CodeMirror instead of Ace. The reason for the change is that CodeMirror allows integrating with the brunch pipeline without including a ton of files into the project as the Ace editor does.