### PR TITLE
Strip leading @ from developer twitter handle

### DIFF
--- a/lib/tilex_web/models/developer.ex
+++ b/lib/tilex_web/models/developer.ex
@@ -20,6 +20,7 @@ defmodule Tilex.Developer do
     struct
     |> cast(params, [:email, :username, :google_id, :twitter_handle, :editor])
     |> validate_required([:email, :username, :google_id])
+    |> clean_twitter_handle
   end
 
   def find_or_create(repo, attrs) do
@@ -43,6 +44,19 @@ defmodule Tilex.Developer do
     name
     |> String.downcase
     |> String.replace(" ", "")
+  end
+
+  defp clean_twitter_handle(changeset) do
+    twitter_handle = get_change(changeset, :twitter_handle)
+
+    if twitter_handle do
+      clean_twitter_handle = String.replace_leading(twitter_handle, "@", "")
+
+      changeset
+      |> put_change(:twitter_handle, clean_twitter_handle)
+    else
+      changeset
+    end
   end
 
   defimpl Phoenix.Param, for: Developer do

--- a/test/models/developer_test.exs
+++ b/test/models/developer_test.exs
@@ -8,4 +8,9 @@ defmodule Tilex.DeveloperTest do
     result = "johnnyappleseed"
     assert Developer.format_username(username) == result
   end
+
+  test "changeset strips leading @ symbol from twitter handle" do
+    changeset = Developer.changeset(%Developer{}, %{twitter_handle: "@tilex"})
+    assert Ecto.Changeset.get_field(changeset, :twitter_handle) == "tilex"
+  end
 end


### PR DESCRIPTION
Strips a leading "@" from the twitter handle if present. 

Fixes #157 

