### PR TITLE
Replace css :not with assert and refute in like post test

### DIFF
--- a/test/features/visitor_views_post_test.exs
+++ b/test/features/visitor_views_post_test.exs
@@ -84,7 +84,8 @@ defmodule VisitorViewsPostTest do
 
     session
     |> assert_has(Query.css("header[data-likes-loaded=true]"))
-    |> assert_has(Query.css(".post .js-like-action:not(.liked)"))
+    |> assert_has(Query.css(".post .js-like-action"))
+    |> refute_has(Query.css(".post .js-like-action.liked"))
 
     post = Repo.get(Post, post.id)
     assert post.likes == 1


### PR DESCRIPTION
This test was randomly failing 3 out of 5 times I'd run it. 

@jwworth I believe you were also having trouble with this one?

How do we feel about asserting that it still has the `.js-like-action` but refuting that `.js-like-action.liked` exists? I ran this 20 times when I went to lunch and had 0 failures so I believe it fixes the flicker. Its a little wordier but I believe its still explicit enough to represent that "`.js-like-action` should exist but `.js-like-action.liked` should not". 