### PR TITLE
Fix/random post path

### DIFF
--- a/lib/tilex_web/controllers/post_controller.ex
+++ b/lib/tilex_web/controllers/post_controller.ex
@@ -69,7 +69,9 @@ defmodule TilexWeb.PostController do
 
     post = Repo.one(query)
 
-    render(conn, "show.html", post: post)
+    conn
+    |> assign(:twitter_shareable, true)
+    |> render("show.html", post: post)
   end
 
   def new(conn, _params) do

--- a/lib/tilex_web/controllers/post_controller.ex
+++ b/lib/tilex_web/controllers/post_controller.ex
@@ -52,11 +52,8 @@ defmodule TilexWeb.PostController do
     |> Repo.preload([:channel])
     |> Repo.preload([:developer])
 
-    canonical_post = Application.get_env(:tilex, :canonical_domain)
-      <> post_path(conn, :show, post)
-
     conn
-    |> assign(:canonical_url, canonical_post)
+    |> assign_post_canonical_url(post)
     |> assign(:twitter_shareable, true)
     |> render("show.#{format}", post: post)
   end
@@ -70,6 +67,7 @@ defmodule TilexWeb.PostController do
     post = Repo.one(query)
 
     conn
+    |> assign_post_canonical_url(post)
     |> assign(:twitter_shareable, true)
     |> render("show.html", post: post)
   end
@@ -187,4 +185,13 @@ defmodule TilexWeb.PostController do
 
   defp extracted_slug(<<slug::size(10)-binary, _rest::binary>>), do: {:ok, slug}
   defp extracted_slug(_), do: :error
+
+  defp assign_post_canonical_url(conn, post) do
+    canonical_post = Application.get_env(:tilex, :canonical_domain)
+                     |> URI.merge(post_path(conn, :show, post))
+                     |> URI.to_string()
+
+    conn
+    |> assign(:canonical_url, canonical_post)
+  end
 end

--- a/lib/tilex_web/templates/post/show.html.eex
+++ b/lib/tilex_web/templates/post/show.html.eex
@@ -1,7 +1,7 @@
 <%= render TilexWeb.SharedView, "post.html",
   conn: @conn,
   post: @post,
-  twitter_shareable: @twitter_shareable
+  twitter_shareable: assigns[:twitter_shareable]
 %>
 
 <%= if TilexWeb.PostView.more_info?(@post.channel) do %>

--- a/test/features/visitor_views_post_test.exs
+++ b/test/features/visitor_views_post_test.exs
@@ -119,4 +119,19 @@ defmodule VisitorViewsPostTest do
     #{TilexWeb.SharedView.display_date(post)}
     """)
   end
+
+  test "via the random url", %{session: session} do
+    post = Factory.insert!(:post)
+
+    session
+    |> visit(post_path(Endpoint, :random))
+    |> PostShowPage.expect_post_attributes(%{
+      title: post.title,
+      body: post.body,
+      channel: post.channel.name,
+      likes_count: 1
+    })
+
+    assert page_title(session) == "#{post.title} - Today I Learned"
+  end
 end


### PR DESCRIPTION
Fixes #170 

This PR does a few things in the process of fixing #170 

I added a test for viewing a post via the random path

I replaced `@twitter_shareable` with `assigns[:twitter_shareable]` that way it will never blow up, no matter if twitter_shareable is set or not. 

I also added the correct post canonical url to the randomly found post. I used the [URI constructor](https://til.hashrocket.com/posts/uyyslounte-joining-uri-parts-in-elixir) @dkarter found  as it formats any weirdly exported CANONICAL_DOMAIN's (double slashes and the like)

And we now show the twitter share link from a random post page. It uses the correct URL to the actual post (not the random one). 