### PR TITLE
Format auth_controller.ex

### DIFF
--- a/lib/tilex_web/controllers/auth_controller.ex
+++ b/lib/tilex_web/controllers/auth_controller.ex
@@ -1,6 +1,6 @@
 defmodule TilexWeb.AuthController do
   use TilexWeb, :controller
-  plug Ueberauth
+  plug(Ueberauth)
 
   alias Guardian.Plug
   alias Tilex.{Developer, Repo}
@@ -13,6 +13,7 @@ defmodule TilexWeb.AuthController do
         conn
         |> put_flash(:info, "Signed in with #{developer.email}")
         |> redirect(to: "/")
+
       {:error, email} when is_binary(email) ->
         conn
         |> put_flash(:info, "#{email} is not a valid email address")
@@ -21,19 +22,19 @@ defmodule TilexWeb.AuthController do
   end
 
   def index(conn, _params) do
-    redirect conn, to: "/auth/google"
+    redirect(conn, to: "/auth/google")
   end
 
   def delete(conn, _params) do
     conn
-    |> Plug.sign_out
+    |> Plug.sign_out()
     |> put_flash(:info, "Signed out")
     |> redirect(to: "/")
   end
 
   defp authenticate(%{info: info, uid: uid}) do
     email = Map.get(info, :email)
-    name  = Developer.format_username(Map.get(info, :name))
+    name = Developer.format_username(Map.get(info, :name))
 
     case String.match?(email, ~r/@hashrocket.com$/) do
       true ->
@@ -44,6 +45,7 @@ defmodule TilexWeb.AuthController do
         }
 
         Developer.find_or_create(Repo, attrs)
+
       _ ->
         {:error, email}
     end


### PR DESCRIPTION
This is the first in a series of pull request plan to open, inspired by Elixir Issue #6643.

It's the result of running the Elixir formatter (shipping with Elixir 1.6) against one file in Tilex. Like the Elixir language, I'd like Tilex to conform to the Elixir formatter and growing style consensus of this community. A final step will be enforcing it on each CI build.

I realize this will create churn, but in my opinion it's worth it. These changes can start conversation about our code, and maybe some pull requests against the Elixir formatter itself.

If you're interested in joining in, install Elixir head (with homebrew for example):

```
$  brew install elixir --HEAD
```

And run the formatter on your file of choice:

```
$ mix format lib/tilex/path/to/my_file.ex
```

Elixir Issue #6643 explains how to use this tool in greater detail.



