### PR TITLE
Use timex to convert dates to correct timezone

### DIFF
--- a/lib/tilex_web/views/shared_view.ex
+++ b/lib/tilex_web/views/shared_view.ex
@@ -2,11 +2,20 @@ defmodule TilexWeb.SharedView do
   use TilexWeb, :view
 
   def display_date(post) do
-    Timex.format!(post.inserted_at, "%B %-e, %Y", :strftime)
+    post.inserted_at
+    |> datetime_in_zone()
+    |> Timex.format!("%B %-e, %Y", :strftime)
   end
 
   def rss_date(post) do
-    Timex.format!(post.inserted_at, "%a, %d %b %Y %H:%M:%S GMT", :strftime)
+    post.inserted_at
+    |> datetime_in_zone()
+    |> Timex.format!("%a, %d %b %Y %H:%M:%S GMT", :strftime)
+  end
+
+  defp datetime_in_zone(datetime) do
+    timezone = Timex.Timezone.get("America/Chicago", datetime)
+    Timex.Timezone.convert(datetime, timezone)
   end
 
   def pluralize(1, object), do: "1 #{object}"


### PR DESCRIPTION
This fixes the issue described in #185

The posts are being created and stored in Chicago timezone. However, when they are displayed, UTC is used. This means looking at a post created in the evening in Chicago will show a display date of the next day. This PR uses the timezone information in the `inserted_at` field to produce a more accurate display time.