### PR TITLE
Reuse HOSTED_DOMAIN var for valid email pattern

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -48,3 +48,4 @@ config :tilex, :organization_name, System.get_env("ORGANIZATION_NAME")
 config :tilex, :canonical_domain, System.get_env("CANONICAL_DOMAIN")
 config :tilex, :cors_origin, "http://localhost:3000"
 config :tilex, :default_twitter_handle, "hashrocket"
+config :tilex, :hosted_domain, System.get_env("HOSTED_DOMAIN")

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -82,6 +82,7 @@ config :tilex, :ga_identifier, System.get_env("GA_IDENTIFIER")
 config :tilex, :canonical_domain, System.get_env("CANONICAL_DOMAIN")
 config :tilex, :default_twitter_handle, System.get_env("DEFAULT_TWITTER_HANDLE")
 config :tilex, :cors_origin, System.get_env("CORS_ORIGIN")
+config :tilex, :hosted_domain, System.get_env("HOSTED_DOMAIN")
 
 config :appsignal, :config,
   active: true

--- a/config/test.exs
+++ b/config/test.exs
@@ -26,6 +26,7 @@ config :tilex, :twitter_notifier, Test.Notifications.Notifiers.Twitter
 config :tilex, :organization_name, "Hashrocket"
 config :tilex, :canonical_domain, "https://til.hashrocket.com"
 config :tilex, :default_twitter_handle, "hashrocket"
+config :tilex, :hosted_domain, "hashrocket.com"
 
 config :tilex, :async_feature_test, (System.get_env("ASYNC_FEATURE_TEST") == "yes")
 
@@ -38,4 +39,3 @@ config :wallaby,
     headless: true
   ],
   screenshot_on_failure: true
-

--- a/lib/tilex_web/controllers/auth_controller.ex
+++ b/lib/tilex_web/controllers/auth_controller.ex
@@ -35,8 +35,9 @@ defmodule TilexWeb.AuthController do
   defp authenticate(%{info: info, uid: uid}) do
     email = Map.get(info, :email)
     name = Developer.format_username(Map.get(info, :name))
+    pattern = ~r/@#{Application.get_env(:tilex, :hosted_domain)}$/
 
-    case String.match?(email, ~r/@hashrocket.com$/) do
+    case String.match?(email, pattern) do
       true ->
         attrs = %{
           email: email,


### PR DESCRIPTION
Takes out an instance of hardcoding of hashrocket.com domain in favor of `HOSTED_DOMAIN`.

`HOSTED_DOMAIN` is already prompted for in the READMe set up steps in conjunction with Google auth vars with the same intent of blocking user auth from non-specified domains.