### PR TITLE
Add repo & description, silencing install warnings

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -1,5 +1,6 @@
 {
-  "repository": {},
+  "repository": "https://github.com/hashrocket/tilex",
+  "description": "TIL is an open-source project by Hashrocket that exists to catalogue the sharing & accumulation of knowledge as it happens day-to-day.",
   "license": "MIT",
   "scripts": {
     "deploy": "brunch build --production",


### PR DESCRIPTION
Adding a description here fixes a warning we were seeing on `npm install`, a documented project setup step.