### PR TITLE
Remove unused Google ID from developer

### DIFF
--- a/lib/tilex_web/controllers/auth_controller.ex
+++ b/lib/tilex_web/controllers/auth_controller.ex
@@ -32,7 +32,7 @@ defmodule TilexWeb.AuthController do
     |> redirect(to: "/")
   end
 
-  defp authenticate(%{info: info, uid: uid}) do
+  defp authenticate(%{info: info}) do
     email = Map.get(info, :email)
     name = Developer.format_username(Map.get(info, :name))
 
@@ -40,8 +40,7 @@ defmodule TilexWeb.AuthController do
       true ->
         attrs = %{
           email: email,
-          username: name,
-          google_id: uid
+          username: name
         }
 
         Developer.find_or_create(Repo, attrs)

--- a/lib/tilex_web/models/developer.ex
+++ b/lib/tilex_web/models/developer.ex
@@ -8,7 +8,6 @@ defmodule Tilex.Developer do
   schema "developers" do
     field(:email, :string)
     field(:username, :string)
-    field(:google_id, :string)
     field(:twitter_handle, :string)
     field(:admin, :boolean)
     field(:editor, :string)
@@ -20,8 +19,8 @@ defmodule Tilex.Developer do
 
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:email, :username, :google_id, :twitter_handle, :editor])
-    |> validate_required([:email, :username, :google_id])
+    |> cast(params, [:email, :username, :twitter_handle, :editor])
+    |> validate_required([:email, :username])
     |> clean_twitter_handle
   end
 

--- a/priv/repo/migrations/20171208181757_remove_google_id.exs
+++ b/priv/repo/migrations/20171208181757_remove_google_id.exs
@@ -1,0 +1,15 @@
+defmodule Tilex.Repo.Migrations.RemoveGoogleId do
+  use Ecto.Migration
+
+  def up do
+    execute """
+      alter table developers drop column google_id;
+    """
+  end
+
+  def down do
+    execute """
+      alter table developers add column google_id varchar;
+    """
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -20,36 +20,32 @@ phoenix_channel = Repo.insert!(%Channel{name: "phoenix", twitter_hashtag: "phoen
 elixir_channel = Repo.insert!(%Channel{name: "elixir", twitter_hashtag: "myelixirstatus"})
 erlang_channel = Repo.insert!(%Channel{name: "erlang", twitter_hashtag: "erlang"})
 
-developer= Repo.insert!(%Developer{email: "developer@hashrocket.com",
-  username: "rickyrocketeer",
-  google_id: "186823978541230597895"
-})
+developer =
+  Repo.insert!(%Developer{email: "developer@hashrocket.com", username: "rickyrocketeer"})
 
 1..100
-  |> Enum.each(fn(_i) ->
+|> Enum.each(fn _i ->
+     Repo.insert!(%Post{
+       title: "Observing Change",
+       body: "A Gold Master Test in Practice",
+       channel: phoenix_channel,
+       developer: developer,
+       slug: Post.generate_slug()
+     })
 
-  Repo.insert!(%Post{
-    title: "Observing Change",
-    body: "A Gold Master Test in Practice",
-    channel: phoenix_channel,
-    developer: developer,
-    slug: Post.generate_slug()
-  })
+     Repo.insert!(%Post{
+       title: "Controlling Your Test Environment",
+       body: "Slow browser integration tests are a hard problem",
+       channel: elixir_channel,
+       developer: developer,
+       slug: Post.generate_slug()
+     })
 
-  Repo.insert!(%Post{
-    title: "Controlling Your Test Environment",
-    body: "Slow browser integration tests are a hard problem",
-    channel: elixir_channel,
-    developer: developer,
-    slug: Post.generate_slug()
-  })
-
-  Repo.insert!(%Post{
-    title: "Testing Elixir",
-    body: "A Rubyist's Journey",
-    channel: erlang_channel,
-    developer: developer,
-    slug: Post.generate_slug()
-  })
-
-end)
+     Repo.insert!(%Post{
+       title: "Testing Elixir",
+       body: "A Rubyist's Journey",
+       channel: erlang_channel,
+       developer: developer,
+       slug: Post.generate_slug()
+     })
+   end)

--- a/test/controllers/auth_controller_test.exs
+++ b/test/controllers/auth_controller_test.exs
@@ -17,7 +17,7 @@ defmodule Tilex.AuthControllerTest do
     assert get_flash(conn, :info) == "Signed in with developer@hashrocket.com"
 
     new_developer =
-      Tilex.Repo.get_by!(Tilex.Developer, google_id: "186823978541230597895")
+      Tilex.Repo.get_by!(Tilex.Developer, email: "developer@hashrocket.com")
     assert new_developer.email == "developer@hashrocket.com"
     assert new_developer.username == "rickyrocketeer"
   end
@@ -26,10 +26,9 @@ defmodule Tilex.AuthControllerTest do
     Factory.insert!(:developer,
                     email: "rebecca@hashrocket.com",
                     name: "Rebecca Rocketeer",
-                    google_id: "126456978541230597123"
                   )
     existing_developer =
-      Tilex.Repo.get_by!(Tilex.Developer, google_id: "126456978541230597123")
+      Tilex.Repo.get_by!(Tilex.Developer, email: "rebecca@hashrocket.com")
     assert existing_developer.email == "rebecca@hashrocket.com"
 
     ueberauth_auth =

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,5 +1,4 @@
 defmodule Tilex.Factory do
-
   alias Tilex.{Channel, Developer, Post, Repo}
   import Ecto.Query
 
@@ -16,15 +15,14 @@ defmodule Tilex.Factory do
       body: "A body",
       channel: find_first_or_build(:channel),
       developer: find_first_or_build(:developer),
-      slug: Post.generate_slug(),
+      slug: Post.generate_slug()
     }
   end
 
   def build(:developer) do
     %Developer{
       email: "developer@hashrocket.com",
-      username: "Ricky Rocketeer",
-      google_id: "186823978541230597895"
+      username: "Ricky Rocketeer"
     }
   end
 
@@ -33,14 +31,14 @@ defmodule Tilex.Factory do
   end
 
   def insert!(factory_name, attributes \\ []) do
-    Repo.insert! build(factory_name, attributes)
+    Repo.insert!(build(factory_name, attributes))
   end
 
   def insert_list!(factory_name, count, attributes \\ []) do
     1..count
-    |> Enum.each(fn(_i) ->
-      Repo.insert! build(factory_name, attributes)
-    end)
+    |> Enum.each(fn _i ->
+         Repo.insert!(build(factory_name, attributes))
+       end)
   end
 
   defp find_first_or_build(:channel) do


### PR DESCRIPTION
Removes a detail returned from Google that we don't currently use.