### PR TITLE
Use modules to allow access to schema (and proper casting)

### DIFF
--- a/lib/tilex/posts.ex
+++ b/lib/tilex/posts.ex
@@ -17,7 +17,7 @@ defmodule Tilex.Posts do
     |> posts
     |> where([p], p.channel_id == ^channel.id)
 
-    posts_count = Repo.one(from p in "posts",
+    posts_count = Repo.one(from p in Post,
       where: p.channel_id == ^channel.id,
       select: fragment("count(*)")
     )
@@ -42,7 +42,7 @@ defmodule Tilex.Posts do
     |> posts
     |> where([p], p.developer_id == ^developer.id)
 
-    posts_count = Repo.one(from p in "posts",
+    posts_count = Repo.one(from p in Post,
       where: p.developer_id == ^developer.id,
       select: fragment("count(*)")
     )


### PR DESCRIPTION
I would suggest using module(s) instead of tables names. I have hacked Tilex to use UUIDs as a primary keys (because we have UUIDs everywhere, so why to make Tilex an exception).

Everything works, except ``Tilex.Posts.by_channel/2`` and ``Tilex.Posts.by_developer/2``. Error would look like:

> Postgrex expected a binary of 16 bytes, got "4154711d-d3c5-4451-883b-11aaf3fef83f". Please make sure the value you are passing matches the definition in your table or in your query or convert the value accordingly.

Which make sense as Ecto is passing strings around, while postgres expects native UUID type. Normally Ecto would cast correctly to ``Ecto.UUID``. But this is not possible here as we don't define schema for the query. One solution would be to rewrite query to:
```elixir
    posts_count = Repo.one(from p in "posts",
      where: p.channel_id == type(^channel.id, :binary_id),
      select: fragment("count(*)")
    )
```
This would fix problem for me, but will break for others with integer ids.