### PR TITLE
Enable parallel testing on CI #2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
       - image: postgres:9.6.5
         environment:
           POSTGRES_USER: postgres
+          ASYNC_FEATURE_TEST: yes
     steps:
       - checkout
       - run: sudo apt-get update

--- a/config/test.exs
+++ b/config/test.exs
@@ -17,7 +17,8 @@ config :tilex, Tilex.Repo,
   database: "tilex_test",
   hostname: "localhost",
   username: "postgres",
-  pool: Ecto.Adapters.SQL.Sandbox
+  pool: Ecto.Adapters.SQL.Sandbox,
+  timeout: 30_000
 
 config :tilex, :organization_name, "Hashrocket"
 config :tilex, :canonical_domain, "https://til.hashrocket.com"

--- a/test/features/developer_creates_post_test.exs
+++ b/test/features/developer_creates_post_test.exs
@@ -10,6 +10,7 @@ defmodule DeveloperCreatesPostTest do
   }
 
   test "fills out form and submits", %{session: session} do
+    Ecto.Adapters.SQL.Sandbox.allow(Tilex.Repo, self(), Process.whereis(Tilex.Notifications))
     Factory.insert!(:channel, name: "phoenix")
     developer = Factory.insert!(:developer)
 


### PR DESCRIPTION
These are the the same changes as #263, but without autoformatter alterations.