### PR TITLE
Identify Languages Not Supported by Highlight.js

### DIFF
--- a/assets/js/syntax_label.js
+++ b/assets/js/syntax_label.js
@@ -1,12 +1,16 @@
 $(function() {
-
   $.fn.syntaxLabel = function() {
     var $el = $(this);
     var $hl = $el.filter('pre code').add($el.find('pre code'));
-    $hl.each(function() {
-      var language = $(this).attr('class').replace(/\s*hljs\s*/, '');
-      $(this).parent().attr('data-language', language);
-    });
-  }
 
+    $hl.each(function() {
+      var language = $(this)
+        .attr('class')
+        .replace(/\s*hljs\s*/, ' ')
+        .trim()
+        .split(' ')[0];
+      $(this).parent().attr('data-language', language);
+      $(this).attr('class', language + ' ' + 'hljs');
+    });
+  };
 });

--- a/assets/js/syntax_label.js
+++ b/assets/js/syntax_label.js
@@ -8,8 +8,10 @@ $(function() {
         .attr('class')
         .replace(/\s*hljs\s*/, ' ')
         .trim()
-        .split(' ')[0];
-      $(this).parent().attr('data-language', language);
+        .replace(/ .*/, '');
+      $(this)
+        .parent()
+        .attr('data-language', language);
       $(this).attr('class', language + ' ' + 'hljs');
     });
   };

--- a/lib/tilex_web/templates/layout/app.html.eex
+++ b/lib/tilex_web/templates/layout/app.html.eex
@@ -122,19 +122,21 @@
     </nav>
     <script src="<%= static_path(@conn, "/js/app.js") %>"></script>
 
+    <%= if Mix.env != :test do %>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/go.min.js"></script>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/elixir.min.js"></script>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/clojure.min.js"></script>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/applescript.min.js"></script>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/javascript.min.js"></script>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/vim.min.js"></script>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/rust.min.js"></script>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/swift.min.js"></script>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/haml.min.js"></script>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/elm.min.js"></script>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/erb.min.js"></script>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/erlang.min.js"></script>
+    <% end %>
     <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/go.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/elixir.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/clojure.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/applescript.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/javascript.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/vim.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/rust.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/swift.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/haml.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/elm.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/erb.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/erlang.min.js"></script>
     <script>hljs.initHighlightingOnLoad();</script>
 
     <%= if Application.get_env(:tilex, :ga_identifier) do %>

--- a/lib/tilex_web/templates/layout/app.html.eex
+++ b/lib/tilex_web/templates/layout/app.html.eex
@@ -122,23 +122,20 @@
     </nav>
     <script src="<%= static_path(@conn, "/js/app.js") %>"></script>
 
-    <!-- syntax highlighting -->
-    <%= if Mix.env != :test do %>
-      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/go.min.js"></script>
-      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/elixir.min.js"></script>
-      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/clojure.min.js"></script>
-      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/applescript.min.js"></script>
-      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/javascript.min.js"></script>
-      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/vim.min.js"></script>
-      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/rust.min.js"></script>
-      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/swift.min.js"></script>
-      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/haml.min.js"></script>
-      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/elm.min.js"></script>
-      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/erb.min.js"></script>
-      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/erlang.min.js"></script>
-      <script>hljs.initHighlightingOnLoad();</script>
-    <% end %>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/go.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/elixir.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/clojure.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/applescript.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/javascript.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/vim.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/rust.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/swift.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/haml.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/elm.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/erb.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/erlang.min.js"></script>
+    <script>hljs.initHighlightingOnLoad();</script>
 
     <%= if Application.get_env(:tilex, :ga_identifier) do %>
       <script type="text/javascript">

--- a/test/features/developer_creates_post_test.exs
+++ b/test/features/developer_creates_post_test.exs
@@ -147,4 +147,79 @@ defmodule DeveloperCreatesPostTest do
     |> PostForm.expect_title_characters_left("37 characters available")
     |> PostForm.expect_title_preview("Example Title")
   end
+
+  test "fills out form with a common language fenced code block", %{session: session} do
+    Ecto.Adapters.SQL.Sandbox.allow(Tilex.Repo, self(), Process.whereis(Tilex.Notifications))
+    Factory.insert!(:channel, name: "ruby")
+    developer = Factory.insert!(:developer)
+
+    session
+    |> sign_in(developer)
+    |> IndexPage.navigate()
+    |> IndexPage.ensure_page_loaded()
+    |> Navigation.click_create_post()
+    |> CreatePostPage.ensure_page_loaded()
+    |> CreatePostPage.fill_in_form(%{
+      title: "Example Title",
+      body: "```ruby\ndef test; end\n```",
+      channel: "ruby"
+    })
+    |> CreatePostPage.submit_form()
+    |> PostShowPage.ensure_info_flash("Post created")
+    |> PostShowPage.ensure_page_loaded("Example Title")
+    |> PostShowPage.expect_fenced_code_block(%{
+      header: "ruby",
+      code: "ruby"
+    })
+  end
+
+  test "fills out form with a made-up language fenced code block", %{session: session} do
+    Ecto.Adapters.SQL.Sandbox.allow(Tilex.Repo, self(), Process.whereis(Tilex.Notifications))
+    Factory.insert!(:channel, name: "madeuplang")
+    developer = Factory.insert!(:developer)
+
+    session
+    |> sign_in(developer)
+    |> IndexPage.navigate()
+    |> IndexPage.ensure_page_loaded()
+    |> Navigation.click_create_post()
+    |> CreatePostPage.ensure_page_loaded()
+    |> CreatePostPage.fill_in_form(%{
+      title: "Example Title",
+      body: "```madeuplang\ndefn testly; end\n```",
+      channel: "madeuplang"
+    })
+    |> CreatePostPage.submit_form()
+    |> PostShowPage.ensure_info_flash("Post created")
+    |> PostShowPage.ensure_page_loaded("Example Title")
+    |> PostShowPage.expect_fenced_code_block(%{
+      header: "madeuplang",
+      code: "madeuplang"
+    })
+  end
+
+  test "fills out form with an inferred language fenced code block", %{session: session} do
+    Ecto.Adapters.SQL.Sandbox.allow(Tilex.Repo, self(), Process.whereis(Tilex.Notifications))
+    Factory.insert!(:channel, name: "ruby")
+    developer = Factory.insert!(:developer)
+
+    session
+    |> sign_in(developer)
+    |> IndexPage.navigate()
+    |> IndexPage.ensure_page_loaded()
+    |> Navigation.click_create_post()
+    |> CreatePostPage.ensure_page_loaded()
+    |> CreatePostPage.fill_in_form(%{
+      title: "Example Title",
+      body: "```\ndef obviously_ruby; puts 'Ruby is great'; end\n```",
+      channel: "ruby"
+    })
+    |> CreatePostPage.submit_form()
+    |> PostShowPage.ensure_info_flash("Post created")
+    |> PostShowPage.ensure_page_loaded("Example Title")
+    |> PostShowPage.expect_fenced_code_block(%{
+      header: "ruby",
+      code: "ruby"
+    })
+  end
 end

--- a/test/support/pages/post_show_page.ex
+++ b/test/support/pages/post_show_page.ex
@@ -53,4 +53,15 @@ defmodule Tilex.Integration.Pages.PostShowPage do
   def click_edit(session) do
     click(session, Query.link("edit"))
   end
+
+  def expect_fenced_code_block(session, attrs \\ %{}) do
+    expected_header = Map.fetch!(attrs, :header)
+    expected_code = Map.fetch!(attrs, :code)
+
+    session
+    |> Browser.find(Query.xpath(".//pre[@data-language='#{expected_header}']"))
+    |> Browser.find(Query.css("code.#{expected_code}.hljs"))
+
+    session
+  end
 end


### PR DESCRIPTION
We recently added a channel that isn't supported by our syntax highlighter, Highlight.js. When a user tries to tag a fenced code block to that language, Highlight can't identify the tag and tries to infer a tag based on the code. The user's tag and the automated tag collide.

This change prioritizes the tag a user sets. If I tag the code Reason, the code block and header get classes and data attributes for 'Reason', in the same style Highlight would use if it knew about Reason. It will still highlight the code as whatever language it thinks it is (JavaScript, PHP, Nginx, etc.), for better or worse.

If I don't tag the block, Highlight tries to infer the language based on the contents of the block, as before.