### PR TITLE
Add guest authoring feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ export BASIC_AUTH_USERNAME=
 export BASIC_AUTH_PASSWORD=
 export CANONICAL_DOMAIN=https://example.com
 export HOSTED_DOMAIN=
+export GUEST_AUTHOR_WHITELIST=
 
 # Google
 export GOOGLE_CLIENT_ID=

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ $ source .env
 Authentication is managed by Omniauth and Google. See the
 [omniauth-google-oauth2 README](https://github.com/zquestz/omniauth-google-oauth2/blob/master/README.md)
 and [Google Oauth 2 docs](https://developers.google.com/identity/protocols/OAuth2WebServer) for
-setup instructions. To allow users from a domain, set those configurations in
+setup instructions. To allow users from a domain and/or comma separated whitelist, set those configurations in
 your environment:
 
 ```
@@ -73,6 +73,7 @@ your environment:
 export GOOGLE_CLIENT_ID="your-key.apps.googleusercontent.com"
 export GOOGLE_CLIENT_SECRET="yoursecret"
 export HOSTED_DOMAIN="your-domain.com"
+export GUEST_AUTHOR_WHITELIST="joedeveloper@otherdomain.com, suziedeveloper@freelancer.com"
 ```
 
 Once set, visit [`localhost:4000/admin`](http://localhost:4000/admin) and log

--- a/config/config.exs
+++ b/config/config.exs
@@ -40,8 +40,7 @@ config :ueberauth, Ueberauth,
        [
          approval_prompt: "force",
          access_type: "offline",
-         default_scope: "email profile",
-         hd: System.get_env("HOSTED_DOMAIN")
+         default_scope: "email profile"
        ]}
   ]
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -26,6 +26,7 @@ config :tilex, :canonical_domain, System.get_env("CANONICAL_DOMAIN")
 config :tilex, :default_twitter_handle, System.get_env("DEFAULT_TWITTER_HANDLE")
 config :tilex, :cors_origin, System.get_env("CORS_ORIGIN")
 config :tilex, :hosted_domain, System.get_env("HOSTED_DOMAIN")
+config :tilex, :guest_author_whitelist, System.get_env("GUEST_AUTHOR_WHITELIST")
 
 # Configures Elixir's Logger
 config :logger, :console,

--- a/test/controllers/auth_controller_test.exs
+++ b/test/controllers/auth_controller_test.exs
@@ -52,6 +52,32 @@ defmodule Tilex.AuthControllerTest do
     assert get_flash(conn, :info) == "developer@gmail.com is not a valid email address"
   end
 
+  test "GET /auth/google/callback with nameless profile", %{conn: conn} do
+    ueberauth_auth =
+      ueberauth_struct("developer@gmail.com", nil, "186823978541230597895")
+
+    conn = assign(conn, :ueberauth_auth, ueberauth_auth)
+
+    conn = get(conn, auth_path(conn, :callback, "google"))
+
+    assert redirected_to(conn) == "/"
+    assert get_flash(conn, :info) == "oauth2 profile is missing a valid name"
+  end
+
+  test "GET /auth/google/callback with whitelisted email", %{conn: conn} do
+    Application.put_env(:tilex, :guest_author_whitelist, "david@byrne.com, bell@thecat.com")
+
+    ueberauth_auth =
+      ueberauth_struct("bell@thecat.com", "Archibald Douglas", "186823978541230597895")
+
+    conn = assign(conn, :ueberauth_auth, ueberauth_auth)
+
+    conn = get(conn, auth_path(conn, :callback, "google"))
+
+    assert redirected_to(conn) == "/"
+    assert get_flash(conn, :info) == "Signed in with bell@thecat.com"
+  end
+
   defp ueberauth_struct(email, name, uid) do
     %Ueberauth.Auth{
       info: %Ueberauth.Auth.Info{


### PR DESCRIPTION
Provide a comma separated list of author emails to allow guests
to post. Refactor authentication error to handle the case when name is
not supplied in the profile since it's never guaranteed to be present.  See  [here]( https://developers.google.com/identity/protocols/OpenIDConnect#obtainuserinfo).

Bit tired so may have missed something.  I'll look over it again tomorrow.