### PR TITLE
Format new test case

### DIFF
--- a/test/controllers/auth_controller_test.exs
+++ b/test/controllers/auth_controller_test.exs
@@ -53,8 +53,7 @@ defmodule Tilex.AuthControllerTest do
   end
 
   test "GET /auth/google/callback with nameless profile", %{conn: conn} do
-    ueberauth_auth =
-      ueberauth_struct("developer@gmail.com", nil, "186823978541230597895")
+    ueberauth_auth = ueberauth_struct("developer@gmail.com", nil, "186823978541230597895")
 
     conn = assign(conn, :ueberauth_auth, ueberauth_auth)
 


### PR DESCRIPTION
This autoformats a new test case with the Elixir 1.6 formatter. Previously our
CI wasn't set up to test forked PR's, allowing this unformatted change onto the
master branch. That setting has been changed and future contributors will be
notified earlier if their code requires formatting.