### PR TITLE
Add Channel to RSS Feed

### DIFF
--- a/lib/tilex_web/controllers/feed_controller.ex
+++ b/lib/tilex_web/controllers/feed_controller.ex
@@ -7,7 +7,7 @@ defmodule TilexWeb.FeedController do
         from(
           p in Tilex.Post,
           order_by: [desc: p.inserted_at],
-          preload: [:developer],
+          preload: [:channel, :developer],
           limit: 25
         )
       )

--- a/lib/tilex_web/templates/feed/index.xml.eex
+++ b/lib/tilex_web/templates/feed/index.xml.eex
@@ -15,9 +15,7 @@
         <description>
           <![CDATA[<%= Tilex.Markdown.to_html(post.body) %>]]>
         </description>
-        <dc:creator>
-          <%= post.developer.username %>
-        </dc:creator>
+        <dc:creator><%= post.developer.username %></dc:creator>
         <pubDate><%= TilexWeb.SharedView.rss_date(post) %></pubDate>
         <guid isPermaLink="true"><%= post_url(@conn, :show, post) %></guid>
       </item>

--- a/lib/tilex_web/templates/feed/index.xml.eex
+++ b/lib/tilex_web/templates/feed/index.xml.eex
@@ -9,7 +9,7 @@
     <%= for post <- @items do %>
       <item>
         <title>
-          <![CDATA[<%= post.title %>]]>
+          <![CDATA[<%= post.title %> - #<%= post.channel.name %>]]>
         </title>
         <link><%= post_url(@conn, :show, post) %></link>
         <description>


### PR DESCRIPTION
This adds the channel name (`#elixir`) to the title of each RSS feed article.

See #283.