### PR TITLE
Robust pagination params

### DIFF
--- a/lib/tilex_web/controllers/post_controller.ex
+++ b/lib/tilex_web/controllers/post_controller.ex
@@ -44,11 +44,7 @@ defmodule TilexWeb.PostController do
     do: redirect(conn, to: "/rss")
 
   def index(conn, params) do
-    page =
-      params
-      |> Map.get("page", "1")
-      |> String.to_integer()
-
+    page = robust_page(params)
     posts = Posts.all(page)
 
     render(conn, "index.html", posts: posts, page: page)
@@ -221,5 +217,19 @@ defmodule TilexWeb.PostController do
 
     conn
     |> assign(:canonical_url, canonical_post)
+  end
+
+  defp robust_page(params) do
+    page_param =
+      params
+      |> Map.get("page", "1")
+
+    page =
+      case Integer.parse(page_param) do
+        :error -> 1
+        {integer, _remainder} -> integer
+      end
+
+    page
   end
 end

--- a/lib/tilex_web/controllers/post_controller.ex
+++ b/lib/tilex_web/controllers/post_controller.ex
@@ -23,11 +23,7 @@ defmodule TilexWeb.PostController do
   end
 
   def index(conn, %{"q" => search_query} = params) do
-    page =
-      params
-      |> Map.get("page", "1")
-      |> String.to_integer()
-
+    page = robust_page(params)
     {posts, posts_count} = Posts.by_search(search_query, page)
 
     render(

--- a/test/controllers/post_controller_test.exs
+++ b/test/controllers/post_controller_test.exs
@@ -6,6 +6,16 @@ defmodule Tilex.PostControllerTest do
     assert html_response(conn, 200) =~ "Today I Learned"
   end
 
+  test "supports a pagination parameter", %{conn: conn} do
+    conn = get(conn, post_path(conn, :index, page: 1))
+    assert html_response(conn, 200) =~ "Today I Learned"
+  end
+
+  test "supports a bad pagination parameter", %{conn: conn} do
+    conn = get(conn, post_path(conn, :index, page: "a"))
+    assert html_response(conn, 200) =~ "Today I Learned"
+  end
+
   test "redirects to root when non-developer visits posts/new path", %{conn: conn} do
     conn = get(conn, post_path(conn, :new))
     assert html_response(conn, 302)

--- a/test/controllers/post_controller_test.exs
+++ b/test/controllers/post_controller_test.exs
@@ -16,6 +16,11 @@ defmodule Tilex.PostControllerTest do
     assert html_response(conn, 200) =~ "Today I Learned"
   end
 
+  test "supports a bad pagination parameter while searching", %{conn: conn} do
+    conn = get(conn, post_path(conn, :index, page: "a", q: "Hot posts"))
+    assert html_response(conn, 200) =~ "Today I Learned"
+  end
+
   test "redirects to root when non-developer visits posts/new path", %{conn: conn} do
     conn = get(conn, post_path(conn, :new))
     assert html_response(conn, 302)


### PR DESCRIPTION
This change fixes the following issue:

Setup: Visit https://til.hashrocket.com/?page=a

### Expected

Pagination parameter is ignored

### Actual

500

This implementation returns the first page when a pagination parameter that cannot be cast to an integer (i.e. "a") is passed, the same thing we do when no pagination parameter is passed.