### PR TITLE
Page parameter refactor

### DIFF
--- a/lib/tilex_web/controllers/post_controller.ex
+++ b/lib/tilex_web/controllers/post_controller.ex
@@ -215,17 +215,12 @@ defmodule TilexWeb.PostController do
     |> assign(:canonical_url, canonical_post)
   end
 
-  defp robust_page(params) do
-    page_param =
-      params
-      |> Map.get("page", "1")
-
-    page =
-      case Integer.parse(page_param) do
-        :error -> 1
-        {integer, _remainder} -> integer
-      end
-
-    page
+  defp robust_page(%{"page" => page}) do
+    case Integer.parse(page) do
+      :error -> 1
+      {integer, _remainder} -> integer
+    end
   end
+
+  defp robust_page(_params), do: 1
 end

--- a/test/controllers/post_controller_test.exs
+++ b/test/controllers/post_controller_test.exs
@@ -7,7 +7,7 @@ defmodule Tilex.PostControllerTest do
   end
 
   test "supports a pagination parameter", %{conn: conn} do
-    conn = get(conn, post_path(conn, :index, page: 1))
+    conn = get(conn, post_path(conn, :index, page: "1"))
     assert html_response(conn, 200) =~ "Today I Learned"
   end
 


### PR DESCRIPTION
This change passes a string as a parameter in test, making the test more realistic. It also takes advantage of pattern matching in the new function.

h/t @tmock12 