### PR TITLE
Tracking

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -48,3 +48,5 @@ config :tilex, Tilex.Repo,
 config :tilex, :page_size, 50
 config :tilex, :cors_origin, "http://localhost:3000"
 config :tilex, :default_twitter_handle, "hashrocket"
+
+config :tilex, :request_tracking, true

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -77,3 +77,4 @@ config :tilex, :ga_identifier, System.get_env("GA_IDENTIFIER")
 config :appsignal, :config, active: true
 
 config :tilex, :page_size, 50
+config :tilex, :request_tracking, System.get_env("REQUEST_TRACKING")

--- a/config/test.exs
+++ b/config/test.exs
@@ -39,3 +39,5 @@ config :wallaby,
     headless: true
   ],
   screenshot_on_failure: true
+
+config :tilex, :request_tracking, true

--- a/lib/tilex/tracking.ex
+++ b/lib/tilex/tracking.ex
@@ -1,0 +1,13 @@
+defmodule Tilex.Tracking do
+  alias Tilex.Repo
+  alias TilexWeb.Endpoint
+
+  def track(conn) do
+    spawn(fn ->
+      with [referer | _] <- Plug.Conn.get_req_header(conn, "referer") do
+        page = String.replace(referer, Endpoint.static_url(), "")
+        Ecto.Adapters.SQL.query!(Repo, "insert into requests (page) values ($1);", [page])
+      end
+    end)
+  end
+end

--- a/lib/tilex/tracking.ex
+++ b/lib/tilex/tracking.ex
@@ -4,9 +4,11 @@ defmodule Tilex.Tracking do
 
   def track(conn) do
     spawn(fn ->
-      with [referer | _] <- Plug.Conn.get_req_header(conn, "referer") do
-        page = String.replace(referer, Endpoint.static_url(), "")
-        Ecto.Adapters.SQL.query!(Repo, "insert into requests (page) values ($1);", [page])
+      if Application.get_env(:tilex, :request_tracking, false) do
+        with [referer | _] <- Plug.Conn.get_req_header(conn, "referer") do
+          page = String.replace(referer, Endpoint.static_url(), "")
+          Ecto.Adapters.SQL.query!(Repo, "insert into requests (page) values ($1);", [page])
+        end
       end
     end)
   end

--- a/lib/tilex/tracking.ex
+++ b/lib/tilex/tracking.ex
@@ -2,9 +2,11 @@ defmodule Tilex.Tracking do
   alias Tilex.Repo
   alias TilexWeb.Endpoint
 
+  @request_tracking Application.get_env(:tilex, :request_tracking, false)
+
   def track(conn) do
     spawn(fn ->
-      if Application.get_env(:tilex, :request_tracking, false) do
+      if @request_tracking do
         with [referer | _] <- Plug.Conn.get_req_header(conn, "referer") do
           page = String.replace(referer, Endpoint.static_url(), "")
           Ecto.Adapters.SQL.query!(Repo, "insert into requests (page) values ($1);", [page])

--- a/lib/tilex_web/controllers/pixel_controller.ex
+++ b/lib/tilex_web/controllers/pixel_controller.ex
@@ -1,0 +1,11 @@
+defmodule TilexWeb.PixelController do
+  use TilexWeb, :controller
+
+  def index(conn, _) do
+    Tilex.Tracking.track(conn)
+
+    conn
+    |> put_resp_header("cache-control", "no-cache, no-store, must-revalidate")
+    |> send_resp(:ok, "")
+  end
+end

--- a/lib/tilex_web/router.ex
+++ b/lib/tilex_web/router.ex
@@ -34,6 +34,7 @@ defmodule TilexWeb.Router do
   end
 
   get("/rss", TilexWeb.FeedController, :index)
+  get("/pixel", TilexWeb.PixelController, :index)
 
   scope "/", TilexWeb do
     pipe_through([:browser, :browser_auth])

--- a/lib/tilex_web/templates/layout/app.html.eex
+++ b/lib/tilex_web/templates/layout/app.html.eex
@@ -37,7 +37,10 @@
       <link rel="canonical" href="<%= @canonical_url %>">
     <% end %>
     <link rel="manifest" href="<%= web_manifest_path(@conn, :index) %>">
-    <script async src="/pixel"></script>
+
+    <%= if request_tracking() do %>
+      <script async src="/pixel"></script>
+    <% end %>
   </head>
 
   <body>

--- a/lib/tilex_web/templates/layout/app.html.eex
+++ b/lib/tilex_web/templates/layout/app.html.eex
@@ -37,6 +37,7 @@
       <link rel="canonical" href="<%= @canonical_url %>">
     <% end %>
     <link rel="manifest" href="<%= web_manifest_path(@conn, :index) %>">
+    <script async src="/pixel"></script>
   </head>
 
   <body>

--- a/lib/tilex_web/views/layout_view.ex
+++ b/lib/tilex_web/views/layout_view.ex
@@ -1,6 +1,8 @@
 defmodule TilexWeb.LayoutView do
   use TilexWeb, :view
 
+  @request_tracking Application.get_env(:tilex, :request_tracking)
+
   def page_title(%{post: post}), do: post.title
   def page_title(%{channel: channel}), do: String.capitalize(channel.name)
   def page_title(%{developer: developer}), do: developer.username
@@ -47,5 +49,9 @@ defmodule TilexWeb.LayoutView do
     """
     TIL is an open-source project by Hashrocket that exists to catalogue the sharing & accumulation of knowledge as it happens day-to-day. Posts have a 200-word limit, and posting is open to any Rocketeer as well as select friends of the team. We hope you enjoy learning along with us.
     """
+  end
+
+  def request_tracking() do
+    @request_tracking
   end
 end

--- a/priv/repo/migrations/20180908171609_create_tracking.exs
+++ b/priv/repo/migrations/20180908171609_create_tracking.exs
@@ -1,0 +1,15 @@
+defmodule Tilex.Repo.Migrations.CreateTracking do
+  use Ecto.Migration
+
+  def up do
+    execute """
+      create table requests (page text not null, request_time timestamp with time zone default now());
+    """
+  end
+
+  def down do
+    execute """
+      drop table requests;
+    """
+  end
+end

--- a/test/features/visitor_views_post_test.exs
+++ b/test/features/visitor_views_post_test.exs
@@ -30,6 +30,14 @@ defmodule VisitorViewsPostTest do
     })
 
     assert page_title(session) == "A special post - Today I Learned"
+
+    assert %{rows: [[path | _]]} =
+             Ecto.Adapters.SQL.query!(
+               Repo,
+               "select page, request_time from requests"
+             )
+
+    assert Regex.match?(~r"#{post.slug}", path)
   end
 
   test "and sees marketing copy, if it exists", %{session: session} do


### PR DESCRIPTION
This is a simple as possible approach to tracking.  Make a request for a javascript file, get the referrer of that request, and store a record in the database with the time and referrer.

Importantly, this feature is OPT IN in production.  For Hashrocket, we anticipate generating 5,000 records per day which would run up against the bottom level database plan very quickly.  For open source users its unreasonable for them to support that level of database traffic.

