### PR TITLE
Fix deprecation warning of unused variable in layout view

### DIFF
--- a/lib/tilex_web/views/layout_view.ex
+++ b/lib/tilex_web/views/layout_view.ex
@@ -50,7 +50,7 @@ defmodule TilexWeb.LayoutView do
          text <- Floki.text(html) do
       text
     else
-      value ->
+      _error ->
         markdown
     end
   end


### PR DESCRIPTION
`value` is unused, so I got a warning 😄 :  
```shell
warning: variable "value" is unused
  lib/tilex_web/views/layout_view.ex:53
```