### PR TITLE
Remove unnecessary get format on post show action

### DIFF
--- a/lib/tilex_web/controllers/post_controller.ex
+++ b/lib/tilex_web/controllers/post_controller.ex
@@ -3,7 +3,6 @@ defmodule TilexWeb.PostController do
   import Ecto.Query
 
   alias Guardian.Plug
-  alias Phoenix.Controller
   alias Tilex.{Channel, Notifications, Liking, Post, Posts}
 
   plug(:load_channels when action in [:new, :create, :edit, :update])
@@ -47,8 +46,6 @@ defmodule TilexWeb.PostController do
   end
 
   def show(%{assigns: %{slug: slug}} = conn, _) do
-    format = Controller.get_format(conn)
-
     post =
       Post
       |> Repo.get_by!(slug: slug)
@@ -58,7 +55,7 @@ defmodule TilexWeb.PostController do
     conn
     |> assign_post_canonical_url(post)
     |> assign(:twitter_shareable, true)
-    |> render("show.#{format}", post: post)
+    |> render(:show, post: post)
   end
 
   def random(conn, _) do


### PR DESCRIPTION
I was poking around and noticed we were using `get_format` unnecessarily in our post controller. 

`render/3` accepts the template as an atom and will do the `get_format` lookup for us - https://hexdocs.pm/phoenix/Phoenix.Controller.html#render/3