### PR TITLE
Make Dev DB config consistent with prod config

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -39,11 +39,18 @@ config :logger, :console, format: "[$level] $message\n"
 config :phoenix, :stacktrace_depth, 20
 
 # Configure your database
-config :tilex, Tilex.Repo,
-  adapter: Ecto.Adapters.Postgres,
-  database: "tilex_dev",
-  hostname: "localhost",
-  pool_size: 10
+if System.get_env("DATABASE_URL") do
+  config :tilex, Tilex.Repo,
+    adapter: Ecto.Adapters.Postgres,
+    url: System.get_env("DATABASE_URL"),
+    pool_size: 10
+else
+  config :tilex, Tilex.Repo,
+    adapter: Ecto.Adapters.Postgres,
+    database: "tilex_dev",
+    hostname: "localhost",
+    pool_size: 10
+end
 
 config :tilex, :page_size, 50
 config :tilex, :cors_origin, "http://localhost:3000"


### PR DESCRIPTION
Allow to optionally configure the Dev DB the same way as the Prod DB is configured via the `DATABASE_URL` environment variable. This enables a couple useful benefits:

- Allows deploying with the dev environment to an external server that runs the DB separately (mostly needed for larger orgs).
- Flexibility to change where the DB is running without forking the code base to make config changes.
- Lays the groundwork for a `docker-compose` setup allowing the DB to vary based on the Docker network set up (more on this in separate PRs).
- Stays backwards compatible in case the `DATABASE_URL` environment variable isn't set.

The main goal here is to provide more flexibility while staying backwards compatible. I love the project and hope to run it locally in our org soon! Thank you for your consideration 😄 