### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,6 @@ RUN mix local.hex --force && \
   mix local.rebar --force && \
   npm install --prefix assets
 
-ENTRYPOINT [ "mix", "ecto.setup", "--force" ]
+ENTRYPOINT [ "./docker-entrypoint.sh" ]
 
 CMD [ "mix", "phx.server" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM elixir:1.6-alpine
+
+ENV APP_HOME=/app
+
+# Install Node.js and dependencies needed for installing Phoenix.
+ENV PACKAGES="git \
+  nodejs \
+  nodejs-npm \
+  build-base \
+"
+RUN apk add --update ${PACKAGES}
+
+# Install Phoenix.
+RUN mix archive.install --force https://github.com/phoenixframework/archives/raw/master/phx_new.ez
+
+# Setup home for application.
+WORKDIR $APP_HOME
+COPY . $APP_HOME
+RUN addgroup -S til && \
+  adduser -S -G til til && \
+  chown --recursive til:til $APP_HOME
+
+# Run everything as the til user now.
+USER til
+
+# Install app depednencies
+RUN mix local.hex --force && \
+  mix deps.get --force && \
+  mix local.rebar --force && \
+  npm install --prefix assets
+
+ENTRYPOINT [ "mix", "ecto.setup", "--force" ]
+
+CMD [ "mix", "phx.server" ]

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -39,11 +39,18 @@ config :logger, :console, format: "[$level] $message\n"
 config :phoenix, :stacktrace_depth, 20
 
 # Configure your database
-config :tilex, Tilex.Repo,
-  adapter: Ecto.Adapters.Postgres,
-  database: "tilex_dev",
-  hostname: "localhost",
-  pool_size: 10
+if System.get_env("DATABASE_URL") do
+  config :tilex, Tilex.Repo,
+    adapter: Ecto.Adapters.Postgres,
+    url: System.get_env("DATABASE_URL"),
+    pool_size: 10
+else
+  config :tilex, Tilex.Repo,
+    adapter: Ecto.Adapters.Postgres,
+    database: "tilex_dev",
+    hostname: "localhost",
+    pool_size: 10
+end
 
 config :tilex, :page_size, 50
 config :tilex, :cors_origin, "http://localhost:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     image: postgres
     ports:
       - "5432:5432"
+    volumes:
+      - ./tmp/db:/var/lib/postgresql/data
   til:
     build: .
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  db:
+    image: postgres
+    ports:
+      - "5432:5432"
+  til:
+    build: .
+    environment:
+      DATABASE_URL: 'postgresql://postgres@db:5432/tilex_dev'
+    image: tilex_til:latest
+    ports:
+      - "4000:4000"
+    depends_on:
+      - db

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+mix ecto.create && mix ecto.migrate
+mix phx.server


### PR DESCRIPTION
This PR adds the ability to package `tilex` in a Docker image and run it locally with `docker-compose` or run it on a server/container orchestrator. I've made use of the `elixir:1.6-alpine` image to try and reduce the size of the end container, though it still weighs in at `505MB`.

This PR also includes a `docker-compose.yml` file to be used both to:
- build the tilex Docker image to later be pushed to DockerHub using the `docker-compose build til` command.
- run tilex locally without having to install Erlang, Phoenix and PostgreSQL. This can be achieved with a `docker-compose up` command.

Thank you for your consideration!

*Note:* This PR depends on #305 to allow reconfiguring the database url which depends on the Docker network. Once I'm able to understand the build issue and if the PR is good, I'll rebase this branch. Thanks!