### PR TITLE
Add httpoison as explicit dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,6 +43,7 @@ defmodule Tilex.Mixfile do
       {:gettext, "~> 0.13"},
       {:guardian, "~> 0.14"},
       {:hackney, "1.8.0"},
+      {:httpoison, "0.13.0"},
       {:html_sanitize_ex, "~> 1.2"},
       {:optimus, "~> 0.1.0"},
       {:phoenix, "~> 1.3.2"},


### PR DESCRIPTION
When we tried out Tilex by deploying it to heroku, the Slack integration did not work. The reason was that posting to Slack depends on `httpoison`, which was not pulled into the build.

`httpoison` is not installed, because it's only an implicit dependency via Wallaby. Wallaby is an [`only: :test`][wallaby] dependency which does not get installed by the [heroku buildpack][].

Deploying a build to Heroku should include the `httpoison` dependency, which is needed to post to the Slack endpoint. This PR accomplishes this by adding httpoison to `mix.exs`, using the version already included in `mix.lock`.


[wallaby]: https://github.com/hashrocket/tilex/blob/a45d0ba3b980a59ed8bfe7d2c1993bfc868a7d1d/mix.exs#L56

[heroku buildpack]: https://github.com/HashNuke/heroku-buildpack-elixir/blob/aea1c4953de0354a6c09b9b9aa5f249575770a61/lib/app_funcs.sh#L79
