### PR TITLE
Override default dev db settings with DATABASE_URL

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -41,6 +41,7 @@ config :phoenix, :stacktrace_depth, 20
 # Configure your database
 config :tilex, Tilex.Repo,
   adapter: Ecto.Adapters.Postgres,
+  url: System.get_env("DATABASE_URL"),
   database: "tilex_dev",
   hostname: "localhost",
   pool_size: 10


### PR DESCRIPTION
A url configuration for the database overrides the component configurations.  When the url is nil or empty string, the component configurations will be in effect.