### PR TITLE
Add Makefile for common dev tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ setup: ## Runs the project setup.
 	npm install --prefix assets/
 
 server: ## Starts the server.
-	sleep 3 && open http://localhost:4000/ &
+	(sleep 3 && open http://localhost:4000/) &
 	mix phx.server
 
 test: ## Tests the project.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help outdated setup
+.PHONY: help outdated setup server test
 
 help: ## Shows this help.
 	@IFS=$$'\n' ; \
@@ -20,3 +20,11 @@ setup: ## Runs the project setup.
 	mix compile
 	mix ecto.setup
 	npm install --prefix assets/
+
+server: ## Starts the server.
+	sleep 3 && open http://localhost:4000/ &
+	mix phx.server
+
+test: ## Tests the project.
+	mix format
+	mix test --trace

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: setup
+
+setup:
+	mix deps.get
+	mix compile
+	mix ecto.setup
+	npm install --prefix assets

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,22 @@
-.PHONY: setup
+.PHONY: help outdated setup
 
-setup:
+help: ## Shows this help.
+	@IFS=$$'\n' ; \
+	help_lines=(`fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//'`); \
+	for help_line in $${help_lines[@]}; do \
+		IFS=$$'#' ; \
+		help_split=($$help_line) ; \
+		help_command=`echo $${help_split[0]} | sed -e 's/^ *//' -e 's/ *$$//'` ; \
+		help_info=`echo $${help_split[2]} | sed -e 's/^ *//' -e 's/ *$$//'` ; \
+		printf "%-30s %s\n" $$help_command $$help_info ; \
+	done
+
+outdated: ## Shows outdated packages.
+	mix hex.outdated
+	npm outdated --prefix assets/
+
+setup: ## Runs the project setup.
 	mix deps.get
 	mix compile
 	mix ecto.setup
-	npm install --prefix assets
+	npm install --prefix assets/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
+#!make
+include .env
+
 .PHONY: help outdated setup server test
+
+.env:
+	cp .env.example .env
 
 help: ## Shows this help.
 	@IFS=$$'\n' ; \

--- a/README.md
+++ b/README.md
@@ -26,9 +26,28 @@ Then, install [Erlang](https://www.erlang.org/),
 
 Next, follow these setup steps:
 
-```
+```shell
 $ git clone https://github.com/hashrocket/tilex
 $ cd tilex
+```
+
+At this point you can use `make` for development commands. To access make help just type: `make` or `make help`. Then you can run make with target(s) such as: `make setup server` and so on. Environment variables will automatically loaded from `.env` file in case you need to change it.
+
+```shell
+$ make
+$ make setup server
+```
+
+Or run commands manually. To set environmental variables, copy the example file:
+
+```shell
+$ cp .env{.example,}
+```
+
+For setting up the project and start the server manually run:
+
+```shell
+$ source .env
 $ mix deps.get
 $ mix ecto.setup
 $ npm install --prefix assets
@@ -43,20 +62,8 @@ Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
 To serve the app at a different port, include the `PORT` environment
 variable when starting the server:
 
-```
+```shell
 $ PORT=4444 mix phx.server
-```
-
-To set environmental variables, copy the example file:
-
-```
-$ cp .env{.example,}
-```
-
-Set your environmental variables in the new file, and then source them:
-
-```
-$ source .env
 ```
 
 ### Authentication
@@ -67,7 +74,7 @@ and [Google Oauth 2 docs](https://developers.google.com/identity/protocols/OAuth
 setup instructions. To allow users from a domain and/or comma separated whitelist, set those configurations in
 your environment:
 
-```
+```shell
 # .env
 
 export GOOGLE_CLIENT_ID="your-key.apps.googleusercontent.com"
@@ -90,7 +97,13 @@ it via your method of choice.
 
 Run the tests with:
 
+```shell
+$ make test
 ```
+
+or:
+
+```shell
 $ mix test
 ```
 
@@ -104,7 +117,7 @@ Hashrocket's deployed instances:
 
 This project contains Mix tasks to deploy our instances; use as follows:
 
-```
+```shell
 $ mix deploy <environment>
 ```
 


### PR DESCRIPTION
Make is a flexible tool for common tasks like development ones and it makes the setup/start local application tech agnostic so easier to jump between different projects.

```shell
$ make
help:                          Shows this help.
outdated:                      Shows outdated packages.
setup:                         Runs the project setup.
server:                        Starts the server.
test:                          Tests the project.
```

I got the `help` task idea from this gist: https://gist.github.com/prwhite/8168133