### PR TITLE
Catch-any route should be last

### DIFF
--- a/lib/tilex_web/router.ex
+++ b/lib/tilex_web/router.ex
@@ -50,7 +50,6 @@ defmodule TilexWeb.Router do
     get("/sitemap.xml", SitemapController, :index)
     get("/manifest.json", WebManifestController, :index)
     get("/random", PostController, :random)
-    get("/:name", ChannelController, :show)
     get("/authors/:name", DeveloperController, :show)
     get("/profile/edit", DeveloperController, :edit)
     put("/profile/edit", DeveloperController, :update)
@@ -59,5 +58,7 @@ defmodule TilexWeb.Router do
     resources("/posts", PostController, param: "titled_slug")
     post("/posts/:slug/like.json", PostController, :like)
     post("/posts/:slug/unlike.json", PostController, :unlike)
+    # catch-any route should be last
+    get("/:name", ChannelController, :show)
   end
 end


### PR DESCRIPTION
This is a very minor one, but in any case... I think it's a good practice to put catch-any routes to the bottom, b/c in other case it's very easy to forget about it and put a new route bellow catch-any (there it will never work).  
I faced this issue during adding some additional features. 