### PR TITLE
Page views report missing data

### DIFF
--- a/lib/tilex/page_views_report.ex
+++ b/lib/tilex/page_views_report.ex
@@ -16,11 +16,11 @@ defmodule Tilex.PageViewsReport do
   defp create_report(rows) do
     last_week_row =
       rows
-      |> Enum.find(fn [_, _, period] -> period == "week" end)
+      |> Enum.find(&match?([_, _, "week"], &1))
 
     best_day_last_week =
       rows
-      |> Stream.filter(fn [_, _, p] -> p == "day" end)
+      |> Stream.filter(&match?([_, _, "day"], &1))
       |> Stream.filter(fn [_, d, _] ->
         Timex.compare(d, Enum.at(last_week_row, 1)) == 1 or
           Timex.compare(d, Enum.at(last_week_row, 1)) == 0
@@ -31,13 +31,13 @@ defmodule Tilex.PageViewsReport do
 
     previous_week_row =
       rows
-      |> Stream.filter(fn [_, _, period] -> period == "week" end)
+      |> Stream.filter(&match?([_, _, "week"], &1))
       |> Enum.reverse()
       |> List.first()
 
     best_day_previous_week =
       rows
-      |> Stream.filter(fn [_, _, p] -> p == "day" end)
+      |> Stream.filter(&match?([_, _, "day"], &1))
       |> Stream.filter(fn [_, d, _] ->
         (Timex.compare(d, Enum.at(previous_week_row, 1)) == 1 or
            Timex.compare(d, Enum.at(previous_week_row, 1)) == 0) and

--- a/lib/tilex/page_views_report.ex
+++ b/lib/tilex/page_views_report.ex
@@ -20,8 +20,8 @@ defmodule Tilex.PageViewsReport do
 
     best_day_last_week =
       rows
-      |> Enum.filter(fn [_, _, p] -> p == "day" end)
-      |> Enum.filter(fn [_, d, _] ->
+      |> Stream.filter(fn [_, _, p] -> p == "day" end)
+      |> Stream.filter(fn [_, d, _] ->
         Timex.compare(d, Enum.at(last_week_row, 1)) == 1 or
           Timex.compare(d, Enum.at(last_week_row, 1)) == 0
       end)
@@ -31,14 +31,14 @@ defmodule Tilex.PageViewsReport do
 
     previous_week_row =
       rows
-      |> Enum.filter(fn [_, _, period] -> period == "week" end)
+      |> Stream.filter(fn [_, _, period] -> period == "week" end)
       |> Enum.reverse()
       |> List.first()
 
     best_day_previous_week =
       rows
-      |> Enum.filter(fn [_, _, p] -> p == "day" end)
-      |> Enum.filter(fn [_, d, _] ->
+      |> Stream.filter(fn [_, _, p] -> p == "day" end)
+      |> Stream.filter(fn [_, d, _] ->
         (Timex.compare(d, Enum.at(previous_week_row, 1)) == 1 or
            Timex.compare(d, Enum.at(previous_week_row, 1)) == 0) and
           Timex.compare(d, Enum.at(last_week_row, 1)) == -1

--- a/lib/tilex/page_views_report.ex
+++ b/lib/tilex/page_views_report.ex
@@ -27,13 +27,13 @@ defmodule Tilex.PageViewsReport do
       end)
       |> Enum.sort_by(fn [c | _] -> c end)
       |> Enum.reverse()
-      |> hd
+      |> List.first()
 
     previous_week_row =
       rows
       |> Enum.filter(fn [_, _, period] -> period == "week" end)
       |> Enum.reverse()
-      |> hd
+      |> List.first()
 
     best_day_previous_week =
       rows
@@ -45,7 +45,7 @@ defmodule Tilex.PageViewsReport do
       end)
       |> Enum.sort_by(fn [c | _] -> c end)
       |> Enum.reverse()
-      |> hd
+      |> List.first()
 
     report = """
     Best Day Last Week:   #{day_output(best_day_last_week)}
@@ -59,6 +59,10 @@ defmodule Tilex.PageViewsReport do
 
   defp day_output([count, date, _period]) do
     "#{String.pad_leading(to_string(count), 10, " ")} #{format(date)}"
+  end
+
+  defp day_output(nil) do
+    String.pad_leading("No data available", 10)
   end
 
   defp format(date) do

--- a/lib/tilex/page_views_report.ex
+++ b/lib/tilex/page_views_report.ex
@@ -58,7 +58,7 @@ defmodule Tilex.PageViewsReport do
   end
 
   defp day_output([count, date, _period]) do
-    "#{String.pad_leading(to_string(count), 10, " ")} #{format(date)}"
+    "#{count |> to_string |> String.pad_leading(10, " ")} #{format(date)}"
   end
 
   defp day_output(nil) do


### PR DESCRIPTION
I was attempting to view the page reports locally but ran into a couple of bugs. 

I had no data from the week before, and we were trying to call `hd/1` on an empty list which returns an `ArgumentError`. Using `List.first/1` will fix that from happening. However, then I was passing nil to `day_output/1` and it wouldn't match. So I added a `No data available` catch function for nil. 

I also made a few other optimizations that i noticed such as using Stream to reduce iterations and `Kernel.match?/2` to remove unnecessary variable bindings. 