### PR TITLE
 👕 Remove elixir warnings

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
-elixir 1.7.0
+elixir 1.6.0
+erlang 20.3.8.9

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #!make
 include .env
 
-.PHONY: help outdated setup server test
+.PHONY: help outdated console setup server test
 
 .env:
 	cp .env.example .env
@@ -21,6 +21,9 @@ outdated: ## Shows outdated packages.
 	mix hex.outdated
 	npm outdated --prefix assets/
 
+console:
+	iex -S mix
+
 setup: ## Runs the project setup.
 	mix deps.get
 	mix compile
@@ -33,4 +36,6 @@ server: ## Starts the server.
 
 test: ## Tests the project.
 	mix format
+	mix credo
+	rm -f screenshots/*
 	mix test --trace

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,2 +1,2 @@
 config_vars_to_export=(BASIC_AUTH_PASSWORD BASIC_AUTH_USERNAME)
-elixir_version=1.5.0
+elixir_version=1.6.0

--- a/lib/mix/tasks/tilex/hdb.ex
+++ b/lib/mix/tasks/tilex/hdb.ex
@@ -56,18 +56,15 @@ defmodule Mix.Tasks.Tilex.Hdb do
 
   defp fetch_heroku_dsn(heroku_app) do
     result =
-      System.cmd(
-        "heroku",
-        [
-          "run",
-          "-a",
-          heroku_app,
-          "--no-notify",
-          "--no-tty",
-          "-x",
-          "sh -c 'echo $DATABASE_URL'"
-        ]
-      )
+      System.cmd("heroku", [
+        "run",
+        "-a",
+        heroku_app,
+        "--no-notify",
+        "--no-tty",
+        "-x",
+        "sh -c 'echo $DATABASE_URL'"
+      ])
 
     case result do
       {dsn, 0} -> {:ok, String.trim(dsn)}

--- a/lib/mix/tasks/tilex/page_views.ex
+++ b/lib/mix/tasks/tilex/page_views.ex
@@ -1,6 +1,5 @@
 defmodule Mix.Tasks.Tilex.PageViews do
   use Mix.Task
-  import Mix.Ecto
 
   @shortdoc "Tilex Page Views: Highlight page views stats for the last couple of weeks"
 

--- a/lib/tilex/stats.ex
+++ b/lib/tilex/stats.ex
@@ -37,13 +37,13 @@ defmodule Tilex.Stats do
     [
       start_date: format_date(start_date),
       end_date: format_date(end_date),
-      channels: Repo.all(posts_by_channels_count |> posts_where.()),
-      developers: Repo.all(posts_by_developers_count |> posts_where.()),
-      developers_count: Repo.one(developers_count |> posts_where.()),
-      most_liked_posts: Repo.all(most_liked_posts |> posts_where.()),
-      hottest_posts: Repo.all(hottest_posts |> posts_where.()),
+      channels: Repo.all(posts_by_channels_count() |> posts_where.()),
+      developers: Repo.all(posts_by_developers_count() |> posts_where.()),
+      developers_count: Repo.one(developers_count() |> posts_where.()),
+      most_liked_posts: Repo.all(most_liked_posts() |> posts_where.()),
+      hottest_posts: Repo.all(hottest_posts() |> posts_where.()),
       posts_for_days: posts_for_days,
-      posts_count: Repo.one(posts_count |> posts_where.()),
+      posts_count: Repo.one(posts_count() |> posts_where.()),
       channels_count:
         Repo.one(
           Channel
@@ -58,17 +58,17 @@ defmodule Tilex.Stats do
   end
 
   def all do
-    posts_for_days = query_posts_for_days!
+    posts_for_days = query_posts_for_days!()
 
     [
-      channels: Repo.all(posts_by_channels_count),
-      developers: Repo.all(posts_by_developers_count),
-      developers_count: Repo.one(developers_count),
-      most_liked_posts: Repo.all(most_liked_posts),
-      hottest_posts: Repo.all(hottest_posts),
+      channels: Repo.all(posts_by_channels_count()),
+      developers: Repo.all(posts_by_developers_count()),
+      developers_count: Repo.one(developers_count()),
+      most_liked_posts: Repo.all(most_liked_posts()),
+      hottest_posts: Repo.all(hottest_posts()),
       posts_for_days: posts_for_days,
-      posts_count: Repo.one(posts_count),
-      channels_count: Repo.one(channels_count),
+      posts_count: Repo.one(posts_count()),
+      channels_count: Repo.one(channels_count()),
       max_count:
         ([1] ++ Enum.map(posts_for_days, fn [_, count] -> count end))
         |> Enum.max()
@@ -131,7 +131,7 @@ defmodule Tilex.Stats do
   defp posts_by_channels_count,
     do:
       from(
-        [p, c] in posts_and_channels,
+        [p, c] in posts_and_channels(),
         group_by: c.name,
         order_by: [desc: count(p.id)],
         select: {count(p.id), c.name}
@@ -140,7 +140,7 @@ defmodule Tilex.Stats do
   defp posts_by_developers_count,
     do:
       from(
-        [p, d] in posts_and_developers,
+        [p, d] in posts_and_developers(),
         group_by: d.username,
         order_by: [desc: count(p.id)],
         select: {count(p.id), d.username}
@@ -149,7 +149,7 @@ defmodule Tilex.Stats do
   defp most_liked_posts,
     do:
       from(
-        [p, c] in posts_and_channels,
+        [p, c] in posts_and_channels(),
         order_by: [desc: p.likes],
         limit: 10,
         select: {p.title, p.likes, p.slug, c.name}

--- a/lib/tilex_web/templates/layout/app.html.eex
+++ b/lib/tilex_web/templates/layout/app.html.eex
@@ -114,7 +114,7 @@
           </div>
         </li>
         <li class="site_nav__statistics">
-          <%= if developer = Guardian.Plug.current_resource(@conn) do %>
+          <%= if Guardian.Plug.current_resource(@conn) do %>
             <%= link("Statistics", to: stats_path(@conn, :developer), class: "site_nav__link") %>
           <% else %>
             <%= link("Statistics", to: stats_path(@conn, :index), class: "site_nav__link") %>

--- a/lib/tilex_web/templates/stats/developer.html.eex
+++ b/lib/tilex_web/templates/stats/developer.html.eex
@@ -7,7 +7,7 @@
       <header>
         <h1>Filter</h1>
       </header>
-      <%= form_for @conn, stats_path(@conn, :developer), [method: :get], fn f -> %>
+      <%= form_for @conn, stats_path(@conn, :developer), [method: :get], fn _f -> %>
         <ul class="filters" id="filter">
           <li><label>Start Date:</label><%= date_input :filter, :start_date, value: @start_date, id: "start-date" %></li>
           <li><label>End Date:</label><%= date_input :filter, :end_date, value: @end_date, id: "end-date" %></li>

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Tilex.Mixfile do
     [
       app: :tilex,
       version: "0.0.1",
-      elixir: "~> 1.5",
+      elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),
       build_embedded: Mix.env() == :prod,

--- a/test/features/developer_views_stats_test.exs
+++ b/test/features/developer_views_stats_test.exs
@@ -2,8 +2,6 @@ defmodule Features.DeveloperViewsStatsTest do
   require IEx
   use Tilex.IntegrationCase, async: Application.get_env(:tilex, :async_feature_test)
 
-  alias TilexWeb.Endpoint
-
   test "sees total number of posts by channel", %{session: session} do
     developer = Factory.insert!(:developer)
 

--- a/test/features/visitor_views_post_test.exs
+++ b/test/features/visitor_views_post_test.exs
@@ -45,8 +45,7 @@ defmodule VisitorViewsPostTest do
     assert Regex.match?(~r"#{post.slug}", path)
   end
 
-  test "the page shows a post with the correct timezone if given",
-       %{session: session} do
+  test "the page shows a post with the correct timezone if given", %{session: session} do
     Application.put_env(:tilex, :date_display_tz, "America/Chicago")
 
     developer = Factory.insert!(:developer)


### PR DESCRIPTION
- [x] 👕 Remove elixir warnings
- [x] 🔧 Set elixir to 1.6.0 on Heroku and for local development
- [x] 🔧 Run credo on make test and remove screenshot files

```shell
warning: unused import Mix.Ecto
  lib/mix/tasks/tilex/page_views.ex:3

warning: variable "posts_by_channels_count" does not exist and is being expanded to "posts_by_channels_count()", please use parentheses to remove the ambiguity or change the variable name
  lib/tilex/stats.ex:40

warning: variable "posts_by_developers_count" does not exist and is being expanded to "posts_by_developers_count()", please use parentheses to remove the ambiguity or change the variable name
  lib/tilex/stats.ex:41

warning: variable "developers_count" does not exist and is being expanded to "developers_count()", please use parentheses to remove the ambiguity or change the variable name
  lib/tilex/stats.ex:42

warning: variable "most_liked_posts" does not exist and is being expanded to "most_liked_posts()", please use parentheses to remove the ambiguity or change the variable name
  lib/tilex/stats.ex:43

warning: variable "hottest_posts" does not exist and is being expanded to "hottest_posts()", please use parentheses to remove the ambiguity or change the variable name
  lib/tilex/stats.ex:44

warning: variable "posts_count" does not exist and is being expanded to "posts_count()", please use parentheses to remove the ambiguity or change the variable name
  lib/tilex/stats.ex:46

warning: variable "query_posts_for_days!" does not exist and is being expanded to "query_posts_for_days!()", please use parentheses to remove the ambiguity or change the variable name
  lib/tilex/stats.ex:61

warning: variable "posts_by_channels_count" does not exist and is being expanded to "posts_by_channels_count()", please use parentheses to remove the ambiguity or change the variable name
  lib/tilex/stats.ex:64

warning: variable "posts_by_developers_count" does not exist and is being expanded to "posts_by_developers_count()", please use parentheses to remove the ambiguity or change the variable name
  lib/tilex/stats.ex:65

warning: variable "developers_count" does not exist and is being expanded to "developers_count()", please use parentheses to remove the ambiguity or change the variable name
  lib/tilex/stats.ex:66

warning: variable "most_liked_posts" does not exist and is being expanded to "most_liked_posts()", please use parentheses to remove the ambiguity or change the variable name
  lib/tilex/stats.ex:67

warning: variable "hottest_posts" does not exist and is being expanded to "hottest_posts()", please use parentheses to remove the ambiguity or change the variable name
  lib/tilex/stats.ex:68

warning: variable "posts_count" does not exist and is being expanded to "posts_count()", please use parentheses to remove the ambiguity or change the variable name
  lib/tilex/stats.ex:70

warning: variable "channels_count" does not exist and is being expanded to "channels_count()", please use parentheses to remove the ambiguity or change the variable name
  lib/tilex/stats.ex:71

warning: variable "posts_and_channels" does not exist and is being expanded to "posts_and_channels()", please use parentheses to remove the ambiguity or change the variable name
  lib/tilex/stats.ex:134

warning: variable "f" is unused
  lib/tilex_web/templates/stats/developer.html.eex:10

warning: variable "posts_and_developers" does not exist and is being expanded to "posts_and_developers()", please use parentheses to remove the ambiguity or change the variable name
  lib/tilex/stats.ex:143

warning: variable "posts_and_channels" does not exist and is being expanded to "posts_and_channels()", please use parentheses to remove the ambiguity or change the variable name
  lib/tilex/stats.ex:152

warning: variable "developer" is unused
  lib/tilex_web/templates/layout/app.html.eex:117

.warning: unused alias Endpoint
  test/features/developer_views_stats_test.exs:5
```