### PR TITLE
🎨  Show deployable envs when deploy task has invalid args

### DIFF
--- a/lib/mix/tasks/deploy.ex
+++ b/lib/mix/tasks/deploy.ex
@@ -6,9 +6,10 @@ defmodule Mix.Tasks.Deploy do
     Deploys our environments.
   """
 
-  def run(["staging"]), do: do_run("staging")
-  def run(["production"]), do: do_run("production")
-  def run(_), do: raise("Unsupported environment")
+  @environments ~w(staging production)
+
+  def run([env]) when env in @environments, do: do_run(env)
+  def run(_), do: raise("Unsupported environment, try one of these: #{inspect(@environments)}")
 
   defp do_run(env) do
     System.cmd("git", ["fetch", "--tags"])


### PR DESCRIPTION
- [x] 🎨  Show deployable envs when deploy task has invalid args

```shell
➜  tilex git:(master) mix deploy
Compiling 1 file (.ex)
** (RuntimeError) Unsupported environment, try one of these: ["staging", "production"]
    lib/mix/tasks/deploy.ex:15: Mix.Tasks.Deploy.run/1
    (mix) lib/mix/task.ex:314: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:80: Mix.CLI.run_task/2
    (elixir) lib/code.ex:677: Code.require_file/2
```