### PR TITLE
Schedule page report notifier every Monday at 9AM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
         environment:
           POSTGRES_USER: postgres
           ASYNC_FEATURE_TEST: yes
+          DATE_DISPLAY_TZ: America/Chicago
     steps:
       - checkout
       - run: sudo apt-get update

--- a/lib/tilex/notifications/notifications.ex
+++ b/lib/tilex/notifications/notifications.ex
@@ -1,6 +1,4 @@
 defmodule Tilex.Notifications do
-  @timezone Application.get_env(:tilex, :date_display_tz, "America/Chicago")
-
   use GenServer
 
   alias Ecto.{Changeset, DateTime}
@@ -89,14 +87,11 @@ defmodule Tilex.Notifications do
   end
 
   defp schedule_report do
-    timezone =
-      case Timex.Timezone.get(@timezone) do
-        {:error, _} -> "America/Chicago"
-        zone -> zone
-      end
+    timezone = Application.get_env(:tilex, :date_display_tz)
 
     milliseconds_until_next_monday_nine_am =
       timezone
+      |> Timex.Timezone.get()
       |> Timex.now()
       |> Timex.shift(days: 7)
       |> Timex.beginning_of_week()


### PR DESCRIPTION


WHAT IT DOES:
Schedules the page views report notifier to be run every Monday at 9AM for whatever timezone you have set (or falls back to Chicago). 