### PR TITLE
Add better runtime error for invalid time zone

### DIFF
--- a/lib/tilex/notifications/notifications.ex
+++ b/lib/tilex/notifications/notifications.ex
@@ -90,11 +90,10 @@ defmodule Tilex.Notifications do
   end
 
   defp schedule_report do
-    timezone = Application.get_env(:tilex, :date_display_tz)
+    timezone = parsed_time_zone()
 
     milliseconds_until_next_monday_nine_am =
       timezone
-      |> Timex.Timezone.get()
       |> Timex.now()
       |> Timex.shift(days: 7)
       |> Timex.beginning_of_week()
@@ -109,5 +108,20 @@ defmodule Tilex.Notifications do
       :generate_page_views_report,
       milliseconds_until_next_monday_nine_am
     )
+  end
+
+  defp parsed_time_zone do
+    Application.get_env(:tilex, :date_display_tz)
+    |> Timex.Timezone.get()
+    |> case do
+      {:error, _error} ->
+        raise(~s(
+        There was an error parsing your time zone.
+        Perhaps you forgot to set Environment Variable DATE_DISPLAY_TZ?
+        ))
+
+      zone ->
+        zone
+    end
   end
 end

--- a/lib/tilex/notifications/notifications.ex
+++ b/lib/tilex/notifications/notifications.ex
@@ -111,7 +111,8 @@ defmodule Tilex.Notifications do
   end
 
   defp parsed_time_zone do
-    Application.get_env(:tilex, :date_display_tz)
+    :tilex
+    |> Application.get_env(:date_display_tz)
     |> Timex.Timezone.get()
     |> case do
       {:error, _error} ->


### PR DESCRIPTION
A few people ran into an issue when they started their app and it wasn't immediately clear that they were missing a timezone. Perhaps a better runtime error message will help? 

BEFORE:
```terminal
** (Mix) Could not start application tilex: Tilex.start(:normal, []) returned an error: shutdown: failed to start child: Tilex.Notifications
    ** (EXIT) an exception was raised:
        ** (ArgumentError) argument error
            :erlang.send_after({:error, :invalid_date}, Tilex.Notifications, :generate_page_views_report)
            (tilex) lib/tilex/notifications/notifications.ex:107: Tilex.Notifications.schedule_report/0
            (tilex) lib/tilex/notifications/notifications.ex:37: Tilex.Notifications.init/1
            (stdlib) gen_server.erl:374: :gen_server.init_it/2
            (stdlib) gen_server.erl:342: :gen_server.init_it/6
            (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```

AFTER:
```terminal
** (Mix) Could not start application tilex: Tilex.start(:normal, []) returned an error: shutdown: failed to start child: Tilex.Notifications
    ** (EXIT) an exception was raised:
        ** (RuntimeError)
        There was an error parsing your time zone.
        Perhaps you forgot to set Environment Variable DATE_DISPLAY_TZ?

            (tilex) lib/tilex/notifications/notifications.ex:118: Tilex.Notifications.parsed_time_zone/0
            (tilex) lib/tilex/notifications/notifications.ex:93: Tilex.Notifications.schedule_report/0
            (tilex) lib/tilex/notifications/notifications.ex:37: Tilex.Notifications.init/1
            (stdlib) gen_server.erl:374: :gen_server.init_it/2
            (stdlib) gen_server.erl:342: :gen_server.init_it/6
            (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```