### PR TITLE
Authenticate stats

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -53,7 +53,7 @@ config :ueberauth, Ueberauth.Strategy.Google.OAuth,
   client_id: System.get_env("GOOGLE_CLIENT_ID"),
   client_secret: System.get_env("GOOGLE_CLIENT_SECRET")
 
-config :tilex, Tilex.Guardian,
+config :tilex, Tilex.Auth.Guardian,
   issuer: "tilex",
   ttl: {30, :days},
   allowed_drift: 2000,

--- a/lib/tilex/auth/guardian.ex
+++ b/lib/tilex/auth/guardian.ex
@@ -1,4 +1,4 @@
-defmodule Tilex.Guardian do
+defmodule Tilex.Auth.Guardian do
   use Guardian, otp_app: :tilex
 
   alias Tilex.{Developer, Repo}

--- a/lib/tilex_web/controllers/auth_controller.ex
+++ b/lib/tilex_web/controllers/auth_controller.ex
@@ -2,12 +2,12 @@ defmodule TilexWeb.AuthController do
   use TilexWeb, :controller
   plug(Ueberauth)
 
-  alias Tilex.{Developer, Repo, Guardian}
+  alias Tilex.{Developer, Repo, Auth}
 
   def callback(%{assigns: %{ueberauth_auth: auth}} = conn, _params) do
     case authenticate(auth) do
       {:ok, developer} ->
-        conn = Guardian.Plug.sign_in(conn, developer)
+        conn = Auth.Guardian.Plug.sign_in(conn, developer)
 
         conn
         |> put_flash(:info, "Signed in with #{developer.email}")
@@ -26,7 +26,7 @@ defmodule TilexWeb.AuthController do
 
   def delete(conn, _params) do
     conn
-    |> Guardian.Plug.sign_out()
+    |> Auth.Guardian.Plug.sign_out()
     |> put_flash(:info, "Signed out")
     |> redirect(to: post_path(conn, :index))
   end

--- a/lib/tilex_web/controllers/developer_controller.ex
+++ b/lib/tilex_web/controllers/developer_controller.ex
@@ -1,8 +1,7 @@
 defmodule TilexWeb.DeveloperController do
   use TilexWeb, :controller
 
-  alias Guardian.Plug
-  alias Tilex.{Developer, Posts, Repo}
+  alias Tilex.{Developer, Posts, Repo, Auth}
 
   def show(conn, %{"name" => username} = params) do
     page =
@@ -23,14 +22,14 @@ defmodule TilexWeb.DeveloperController do
   end
 
   def edit(conn, _params) do
-    developer = Plug.current_resource(conn)
+    developer = Auth.Guardian.Plug.current_resource(conn)
     changeset = Developer.changeset(developer)
 
     render(conn, "edit.html", developer: developer, changeset: changeset)
   end
 
   def update(conn, %{"developer" => developer_params}) do
-    developer = Plug.current_resource(conn)
+    developer = Auth.Guardian.Plug.current_resource(conn)
 
     changeset = Developer.changeset(developer, developer_params)
 

--- a/lib/tilex_web/controllers/stats_controller.ex
+++ b/lib/tilex_web/controllers/stats_controller.ex
@@ -7,8 +7,8 @@ defmodule TilexWeb.StatsController do
 
   plug(
     Guardian.EnsureAuthenticated,
-    [handler: __MODULE__]
-    when action in ~w(admin)
+    [error_handler: __MODULE__]
+    when action in ~w(developer)a
   )
 
   def auth_error(conn, {_failure_type, _reason}, _opts) do

--- a/lib/tilex_web/controllers/test/auth_controller.ex
+++ b/lib/tilex_web/controllers/test/auth_controller.ex
@@ -1,11 +1,11 @@
 defmodule TilexWeb.Test.AuthController do
   use TilexWeb, :controller
 
-  alias Tilex.{Developer, Repo, Guardian}
+  alias Tilex.{Developer, Repo, Auth}
 
   def index(conn, params) do
     developer = Repo.get_by!(Developer, id: params["id"])
-    conn = Guardian.Plug.sign_in(conn, developer)
+    conn = Auth.Guardian.Plug.sign_in(conn, developer)
 
     redirect(conn, to: post_path(conn, :index))
   end

--- a/lib/tilex_web/router.ex
+++ b/lib/tilex_web/router.ex
@@ -14,7 +14,10 @@ defmodule TilexWeb.Router do
   end
 
   pipeline :browser_auth do
-    plug(Guardian.Plug.Pipeline, module: Tilex.Guardian)
+    plug(Guardian.Plug.Pipeline,
+      module: Tilex.Auth.Guardian
+    )
+
     plug(Guardian.Plug.VerifySession)
     plug(Guardian.Plug.LoadResource, allow_blank: true)
   end

--- a/test/controllers/stats_controller_test.exs
+++ b/test/controllers/stats_controller_test.exs
@@ -1,0 +1,8 @@
+defmodule Tilex.StatsControllerTest do
+  use TilexWeb.ConnCase, async: true
+
+  test 'developer/2 redirects to stats index when unauthenticated', %{conn: conn} do
+    response = get(conn, stats_path(conn, :developer))
+    assert html_response(response, 302)
+  end
+end


### PR DESCRIPTION
Fun story, I'm in the process of making some upgrades to the Guardian configuration and I happened to notice we are supposed to be authenticating the developer stats page? but never did...

This PR contains a namespace for Guardian under Auth and more importantly we are now authenticating the developer stats page and have a spec for it. 