### PR TITLE
Add error handler for Guardian plug pipeline

### DIFF
--- a/lib/tilex/auth/error_handler.ex
+++ b/lib/tilex/auth/error_handler.ex
@@ -1,0 +1,15 @@
+defmodule Tilex.Auth.ErrorHandler do
+  import Plug.Conn
+  import TilexWeb.Router.Helpers
+  import Phoenix.Controller, only: [put_flash: 3, redirect: 2]
+
+  @behaviour Guardian.Plug.ErrorHandler
+
+  @impl Guardian.Plug.ErrorHandler
+  def auth_error(conn, {_failure_type, _reason}, _opts) do
+    conn
+    |> put_status(302)
+    |> put_flash(:info, "Authentication required")
+    |> redirect(to: post_path(conn, :index))
+  end
+end

--- a/lib/tilex_web/router.ex
+++ b/lib/tilex_web/router.ex
@@ -15,7 +15,8 @@ defmodule TilexWeb.Router do
 
   pipeline :browser_auth do
     plug(Guardian.Plug.Pipeline,
-      module: Tilex.Auth.Guardian
+      module: Tilex.Auth.Guardian,
+      error_handler: Tilex.Auth.ErrorHandler
     )
 
     plug(Guardian.Plug.VerifySession)


### PR DESCRIPTION
I'm hoping adding an error_handler here will either fix or give us further insight into the error @jbranchaud is having. This should fix where the current stack trace is blowing up on. 

```
`error_handler` not set in Guardian pipeline
(guardian) lib/guardian/plug/pipeline.ex:233: Guardian.Plug.Pipeline.raise_error/1
(guardian) lib/guardian/plug/verify_session.ex:67: Guardian.Plug.VerifySession.verify_session/2
``` 