### PR TITLE
Serve fingerprinted assets

### DIFF
--- a/compile
+++ b/compile
@@ -5,3 +5,4 @@ else
 fi
 
 cd $phoenix_dir
+mix "${phoenix_ex}.digest"


### PR DESCRIPTION
While doing something totally unrelated, I noticed we weren't serving fingerprinted assets (css and JS) in production. This fixes that. 

You can see on this PRs review app the assets are now properly fingerprinted. 