### PR TITLE
Replace httpoison with httpc

### DIFF
--- a/lib/tilex/notifications/notifiers/slack.ex
+++ b/lib/tilex/notifications/notifiers/slack.ex
@@ -34,7 +34,14 @@ defmodule Tilex.Notifications.Notifiers.Slack do
   end
 
   defp send_slack_message(message) do
-    endpoint = System.get_env("slack_post_endpoint")
-    HTTPoison.post("https://hooks.slack.com" <> endpoint, "{\"text\": \"#{message}\"}")
+    endpoint =
+      String.to_charlist("https://hooks.slack.com" <> System.get_env("slack_post_endpoint"))
+
+    :httpc.request(
+      :post,
+      {endpoint, [], 'application/json', "{\"text\": \"#{message}\"}"},
+      [],
+      []
+    )
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,6 @@ defmodule Tilex.Mixfile do
       {:guardian, "~> 1.0"},
       {:hackney, "1.15.1"},
       {:html_sanitize_ex, "~> 1.2"},
-      {:httpoison, "1.5.0"},
       {:jason, "~> 1.0"},
       {:optimus, "~> 0.1.0"},
       {:phoenix, "~> 1.4.0"},


### PR DESCRIPTION
Given this was the only place we are using HTTPoision, I see no reason not to just use Erlangs built in httpc. IMHO the more dependencies we can remove the better as it reduces potential security intrusions. 

Unfortunately Wallaby still relies on it, but at least we won't. 