### PR TITLE
Add display swap param to google fonts

### DIFF
--- a/lib/tilex_web/templates/error/404.html.eex
+++ b/lib/tilex_web/templates/error/404.html.eex
@@ -8,8 +8,8 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-    <link href='//fonts.googleapis.com/css?family=Raleway:700,900' rel='stylesheet' type='text/css'>
-    <link href='//fonts.googleapis.com/css?family=Lora:400,700italic,700,400italic' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Raleway:700,900&display=swap' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Lora:400,700italic,700,400italic&display=swap' rel='stylesheet' type='text/css'>
 
     <style>
       html {

--- a/lib/tilex_web/templates/error/500.html.eex
+++ b/lib/tilex_web/templates/error/500.html.eex
@@ -8,8 +8,8 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-    <link href='//fonts.googleapis.com/css?family=Raleway:700,900' rel='stylesheet' type='text/css'>
-    <link href='//fonts.googleapis.com/css?family=Lora:400,700italic,700,400italic' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Raleway:700,900&display=swap' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Lora:400,700italic,700,400italic&display=swap' rel='stylesheet' type='text/css'>
 
     <style>
       html {

--- a/lib/tilex_web/templates/layout/app.html.eex
+++ b/lib/tilex_web/templates/layout/app.html.eex
@@ -23,8 +23,8 @@
     <meta name="twitter:description" content="<%= twitter_description(assigns[:post]) %>">
     <meta name="twitter:image" content=<%= twitter_image_url(assigns[:post]) %>>
 
-    <link href='//fonts.googleapis.com/css?family=Raleway:700,900' rel='stylesheet' type='text/css'>
-    <link href='//fonts.googleapis.com/css?family=Lora:400,700italic,700,400italic' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Raleway:700,900&display=swap' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Lora:400,700italic,700,400italic&display=swap' rel='stylesheet' type='text/css'>
     <link rel="alternate feed" type="application/rss+xml" title="Today I Learned" href="<%= feed_path(@conn, :index) %>">
 
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/atom-one-dark.min.css">


### PR DESCRIPTION
Google fonts now supports `&display=swap` which should help out performance. This is actually the default when you copy directly from Google fonts now. 

![Screen Shot 2019-05-24 at 3 39 38 PM](https://user-images.githubusercontent.com/1124585/58328193-2e35ee00-7e3a-11e9-9934-652021bc7b9e.png)
