### PR TITLE
Remove chart that doesn't work in this context

### DIFF
--- a/lib/tilex/stats.ex
+++ b/lib/tilex/stats.ex
@@ -32,8 +32,6 @@ defmodule Tilex.Stats do
       )
     end
 
-    posts_for_days = query_posts_for_days!(start_time, end_time)
-
     [
       start_date: format_date(start_date),
       end_date: format_date(end_date),
@@ -42,7 +40,6 @@ defmodule Tilex.Stats do
       developers_count: Repo.one(developers_count() |> posts_where.()),
       most_liked_posts: Repo.all(most_liked_posts() |> posts_where.()),
       hottest_posts: Repo.all(hottest_posts() |> posts_where.()),
-      posts_for_days: posts_for_days,
       posts_count: Repo.one(posts_count() |> posts_where.()),
       channels_count:
         Repo.one(
@@ -50,10 +47,7 @@ defmodule Tilex.Stats do
           |> join(:inner, [c], p in assoc(c, :posts))
           |> select([c, p], fragment("count(distinct(c0.id))"))
           |> where([c, p], p.inserted_at < ^end_time and p.inserted_at > ^start_time)
-        ),
-      max_count:
-        ([1] ++ Enum.map(posts_for_days, fn [_, count] -> count end))
-        |> Enum.max()
+        )
     ]
   end
 

--- a/lib/tilex_web/templates/stats/developer.html.eex
+++ b/lib/tilex_web/templates/stats/developer.html.eex
@@ -15,18 +15,6 @@
         </ul>
       <% end %>
     </article>
-    <article>
-      <header>
-        <h1>Last 30 days</h1>
-      </header>
-      <ul class="activity_chart" id="activity">
-        <%= for [date, count] <- @posts_for_days do %>
-          <li data-amount="<%= count %>" data-date="<%= Timex.format!(date, "%a, %b %-e", :strftime)%>">
-            <div class="activity_chart_bar" style="height: <%= (count * 100) / @max_count %>%;"></div>
-          </li>
-        <% end %>
-      </ul>
-    </article>
     <article class="hottest_posts">
       <header>
         <h1>Hottest posts</h1>

--- a/test/features/developer_views_stats_test.exs
+++ b/test/features/developer_views_stats_test.exs
@@ -1,12 +1,8 @@
 defmodule Features.DeveloperViewsStatsTest do
   use Tilex.IntegrationCase, async: Application.get_env(:tilex, :async_feature_test)
 
-  setup_all do
+  test "sees total number of posts by channel", %{session: session} do
     developer = Factory.insert!(:developer)
-    {:ok, developer: developer}
-  end
-
-  test "sees total number of posts by channel", %{session: session, developer: developer} do
     phoenix_channel = Factory.insert!(:channel, name: "phoenix")
     other_channel = Factory.insert!(:channel, name: "other")
 
@@ -60,7 +56,9 @@ defmodule Features.DeveloperViewsStatsTest do
     assert text_without_newlines(other_channel) =~ "#other 3 posts"
   end
 
-  test "does not see sees til activity chart", %{session: session, developer: developer} do
+  test "does not see sees til activity chart", %{session: session} do
+    developer = Factory.insert!(:developer)
+
     session
     |> sign_in(developer)
     |> visit("/developer/statistics")

--- a/test/features/developer_views_stats_test.exs
+++ b/test/features/developer_views_stats_test.exs
@@ -59,4 +59,12 @@ defmodule Features.DeveloperViewsStatsTest do
 
     assert text_without_newlines(other_channel) =~ "#other 3 posts"
   end
+
+  test "does not see sees til activity chart", %{session: session, developer: developer} do
+    session
+    |> sign_in(developer)
+    |> visit("/developer/statistics")
+
+    refute_has(session, Query.css("ul#activity"))
+  end
 end

--- a/test/features/developer_views_stats_test.exs
+++ b/test/features/developer_views_stats_test.exs
@@ -1,9 +1,12 @@
 defmodule Features.DeveloperViewsStatsTest do
   use Tilex.IntegrationCase, async: Application.get_env(:tilex, :async_feature_test)
 
-  test "sees total number of posts by channel", %{session: session} do
+  setup_all do
     developer = Factory.insert!(:developer)
+    {:ok, developer: developer}
+  end
 
+  test "sees total number of posts by channel", %{session: session, developer: developer} do
     phoenix_channel = Factory.insert!(:channel, name: "phoenix")
     other_channel = Factory.insert!(:channel, name: "other")
 

--- a/test/features/developer_views_stats_test.exs
+++ b/test/features/developer_views_stats_test.exs
@@ -1,5 +1,4 @@
 defmodule Features.DeveloperViewsStatsTest do
-  require IEx
   use Tilex.IntegrationCase, async: Application.get_env(:tilex, :async_feature_test)
 
   test "sees total number of posts by channel", %{session: session} do


### PR DESCRIPTION
This chart was not designed to work with a signed-in developer's ability to change the date ranges. As such, it cannot currently show data to someone who is logged in. Until somebody wants to implement it, we are removing it.