### PR TITLE
⚡️ Setup async tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ export CANONICAL_DOMAIN=https://example.com
 export HOSTED_DOMAIN=
 export GUEST_AUTHOR_WHITELIST=
 export DATE_DISPLAY_TZ=America/Chicago
-export ASYNC_FEATURE_TEST=true
+export ASYNC_FEATURE_TEST=yes
 
 # Google
 export GOOGLE_CLIENT_ID=

--- a/Makefile
+++ b/Makefile
@@ -38,4 +38,4 @@ test: ## Tests the project.
 	mix format
 	mix credo
 	rm -f screenshots/*
-	mix test --trace
+	mix test

--- a/config/test.exs
+++ b/config/test.exs
@@ -43,3 +43,5 @@ config :wallaby,
   screenshot_on_failure: true
 
 config :tilex, :request_tracking, true
+
+config :appsignal, :config, active: false

--- a/config/test.exs
+++ b/config/test.exs
@@ -18,6 +18,7 @@ config :tilex, Tilex.Repo,
   hostname: "localhost",
   username: "postgres",
   pool: Ecto.Adapters.SQL.Sandbox,
+  pool_size: 50,
   timeout: 30_000
 
 config :tilex, :organization_name, "Hashrocket"

--- a/test/controllers/api/developer_post_controller_test.exs
+++ b/test/controllers/api/developer_post_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule Tilex.Api.DeveloperPostControllerTest do
-  use TilexWeb.ConnCase
+  use TilexWeb.ConnCase, async: true
 
   alias Tilex.Factory
 

--- a/test/controllers/auth_controller_test.exs
+++ b/test/controllers/auth_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule Tilex.AuthControllerTest do
-  use TilexWeb.ConnCase
+  use TilexWeb.ConnCase, async: true
 
   alias Tilex.Factory
 

--- a/test/controllers/post_controller_test.exs
+++ b/test/controllers/post_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule Tilex.PostControllerTest do
-  use TilexWeb.ConnCase
+  use TilexWeb.ConnCase, async: true
 
   test "lists all entries on index", %{conn: conn} do
     conn = get(conn, post_path(conn, :index))

--- a/test/features/admin_edits_post_test.exs
+++ b/test/features/admin_edits_post_test.exs
@@ -1,5 +1,5 @@
 defmodule AdminEditsPostTest do
-  use Tilex.IntegrationCase, async: Application.get_env(:tilex, :async_feature_test)
+  use Tilex.IntegrationCase, async: true
 
   alias Tilex.Integration.Pages.{
     PostForm,

--- a/test/features/developer_creates_post_test.exs
+++ b/test/features/developer_creates_post_test.exs
@@ -1,5 +1,5 @@
 defmodule DeveloperCreatesPostTest do
-  use Tilex.IntegrationCase, async: Application.get_env(:tilex, :async_feature_test)
+  use Tilex.IntegrationCase, async: false
 
   alias Tilex.Integration.Pages.{
     Navigation,

--- a/test/features/developer_edits_post_test.exs
+++ b/test/features/developer_edits_post_test.exs
@@ -1,5 +1,5 @@
 defmodule DeveloperEditsPostTest do
-  use Tilex.IntegrationCase, async: Application.get_env(:tilex, :async_feature_test)
+  use Tilex.IntegrationCase, async: true
 
   alias Tilex.Integration.Pages.{
     PostForm,

--- a/test/features/developer_signs_out_test.exs
+++ b/test/features/developer_signs_out_test.exs
@@ -1,5 +1,5 @@
 defmodule Features.DeveloperSignsOutTest do
-  use Tilex.IntegrationCase, async: Application.get_env(:tilex, :async_feature_test)
+  use Tilex.IntegrationCase, async: true
 
   test 'signs out and sees a flash message', %{:session => session} do
     developer = Factory.insert!(:developer)

--- a/test/features/developer_views_stats_test.exs
+++ b/test/features/developer_views_stats_test.exs
@@ -1,5 +1,5 @@
 defmodule Features.DeveloperViewsStatsTest do
-  use Tilex.IntegrationCase, async: Application.get_env(:tilex, :async_feature_test)
+  use Tilex.IntegrationCase, async: true
 
   test "sees total number of posts by channel", %{session: session} do
     developer = Factory.insert!(:developer)

--- a/test/features/visitor_searches_posts_test.exs
+++ b/test/features/visitor_searches_posts_test.exs
@@ -1,5 +1,5 @@
 defmodule VisiorSearchesPosts do
-  use Tilex.IntegrationCase, async: Application.get_env(:tilex, :async_feature_test)
+  use Tilex.IntegrationCase, async: true
 
   def fill_in_search(session, query) do
     session

--- a/test/features/visitor_views_channel_test.exs
+++ b/test/features/visitor_views_channel_test.exs
@@ -1,5 +1,5 @@
 defmodule Features.VisitorViewsChannelTest do
-  use Tilex.IntegrationCase, async: Application.get_env(:tilex, :async_feature_test)
+  use Tilex.IntegrationCase, async: true
 
   test "sees associated posts", %{session: session} do
     target_channel = Factory.insert!(:channel, name: "phoenix")

--- a/test/features/visitor_views_channel_test.exs
+++ b/test/features/visitor_views_channel_test.exs
@@ -25,12 +25,15 @@ defmodule Features.VisitorViewsChannelTest do
   test "the page has a list of paginated posts", %{session: session} do
     channel = Factory.insert!(:channel, name: "smalltalk")
 
+    {:ok, inserted_at} = DateTime.from_naive(~N[2019-06-28 16:05:47], "Etc/UTC")
+
     Enum.each(1..6, fn x ->
       Factory.insert!(
         :post,
         title: "Title#{x}",
         body: "It starts with Rails and ends with Elixir",
-        channel: channel
+        channel: channel,
+        inserted_at: DateTime.add(inserted_at, x)
       )
     end)
 

--- a/test/features/visitor_views_developer_test.exs
+++ b/test/features/visitor_views_developer_test.exs
@@ -1,5 +1,5 @@
 defmodule Features.VisitorViewsDeveloper do
-  use Tilex.IntegrationCase, async: Application.get_env(:tilex, :async_feature_test)
+  use Tilex.IntegrationCase, async: true
 
   alias TilexWeb.Endpoint
 

--- a/test/features/visitor_views_post_test.exs
+++ b/test/features/visitor_views_post_test.exs
@@ -36,13 +36,16 @@ defmodule VisitorViewsPostTest do
 
     assert page_title(session) == "A special post - Today I Learned"
 
-    assert %{rows: [[path | _]]} =
-             Ecto.Adapters.SQL.query!(
-               Repo,
-               "select page, request_time from requests"
-             )
+    last_request_query =
+      from(r in "requests",
+        select: %{page: r.page},
+        order_by: [desc: r.request_time],
+        limit: 1
+      )
 
-    assert Regex.match?(~r"#{post.slug}", path)
+    assert %{page: path} = Repo.one(last_request_query)
+
+    assert path =~ post.slug
   end
 
   test "the page shows a post with the correct timezone if given", %{session: session} do

--- a/test/features/visitor_views_rss_feed_test.exs
+++ b/test/features/visitor_views_rss_feed_test.exs
@@ -1,5 +1,5 @@
 defmodule VisitorViewsRSSFeed do
-  use Tilex.IntegrationCase, async: Application.get_env(:tilex, :async_feature_test)
+  use Tilex.IntegrationCase, async: true
 
   test "via the legacy atom query parameter", %{session: session} do
     visit(session, "/?format=atom")

--- a/test/features/visitor_views_stats_test.exs
+++ b/test/features/visitor_views_stats_test.exs
@@ -1,5 +1,5 @@
 defmodule Features.VisitorViewsStatsTest do
-  use Tilex.IntegrationCase, async: Application.get_env(:tilex, :async_feature_test)
+  use Tilex.IntegrationCase, async: true
 
   test "sees total number of posts by channel", %{session: session} do
     target_channel = Factory.insert!(:channel, name: "phoenix")

--- a/test/features/visitor_visits_homepage_test.exs
+++ b/test/features/visitor_visits_homepage_test.exs
@@ -1,5 +1,5 @@
 defmodule VisitorVisitsHomepageTest do
-  use Tilex.IntegrationCase, async: Application.get_env(:tilex, :async_feature_test)
+  use Tilex.IntegrationCase, async: true
 
   test "the page does not have a Create Post link", %{session: session} do
     visit(session, "/")

--- a/test/lib/tilex/rate_limiter_test.exs
+++ b/test/lib/tilex/rate_limiter_test.exs
@@ -1,5 +1,5 @@
 defmodule Tilex.RateLimiterTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Tilex.RateLimiter
   alias Tilex.DateTimeMock

--- a/test/models/channel_test.exs
+++ b/test/models/channel_test.exs
@@ -1,5 +1,5 @@
 defmodule Tilex.ChannelTest do
-  use Tilex.ModelCase
+  use Tilex.ModelCase, async: true
 
   alias Tilex.{Channel, Factory}
 

--- a/test/models/channel_test.exs
+++ b/test/models/channel_test.exs
@@ -1,5 +1,5 @@
 defmodule Tilex.ChannelTest do
-  use Tilex.ModelCase, async: true
+  use Tilex.ModelCase, async: false
 
   alias Tilex.{Channel, Factory}
 

--- a/test/models/developer_test.exs
+++ b/test/models/developer_test.exs
@@ -1,5 +1,5 @@
 defmodule Tilex.DeveloperTest do
-  use Tilex.ModelCase
+  use Tilex.ModelCase, async: true
 
   alias Tilex.Developer
 

--- a/test/models/post_test.exs
+++ b/test/models/post_test.exs
@@ -1,5 +1,5 @@
 defmodule Tilex.PostTest do
-  use Tilex.ModelCase
+  use Tilex.ModelCase, async: true
 
   alias Tilex.Post
 

--- a/test/views/shared_view_test.exs
+++ b/test/views/shared_view_test.exs
@@ -1,5 +1,5 @@
 defmodule Tilex.SharedViewTest do
-  use TilexWeb.ConnCase
+  use TilexWeb.ConnCase, async: true
 
   import TilexWeb.SharedView
 


### PR DESCRIPTION
This PR reduces the test suite from `63.2 seconds` to `39.7 seconds`

- [x] ⚡️ Add missing async option on tests
- [x] 🔧 Fix ASYNC_FEATURE_TEST .env.example value
- [x] Remove appsignal warning message from test suite
- [x] ✅ Fix intermittent test due to sorting by inserted_at (:eyes: Explanation 1)
- [x] 🔧 Increase Ecto pool_size to avoid ConnectionError (:eyes: Explanation 2)
- [x] Make visitor_views_post test less brittle (:eyes: Explanation 3)
- [x] 🔧 Configure current parallelable tests to be async (:eyes: Explanation 4)

## Explanations

1. Elixir is quite fast so posts are being created with same inserted_at sometimes which causes a feature test on visitor_views_channel to fail as the posts retrieved by the controller are being sorted by inserted_at field.
2. DBConnection.ConnectionError: connection not available and request was dropped from queue. This exception was happening when running mix test in parallel locally with 8 cores, which means max_cases of 16 on ExUnit. The default value is 10 and this commit changes it to 50.
3. The current test suite leave dirty data on the `requests` table when it runs in parallel as there are some feature tests that ends up tracking accesses outside of the Ecto Sandbox process for some tests. So this commit intends to make this test less brittle by changing the query to get the last created request on the db to compare the path. I also changed the match to use the `=~` operator for better messaging on errors.
4. There are some tests that are safe to run in parallel and some that are not. This commit intends to make them explicit async or not and then we can start to investigate each case separately.
