### PR TITLE
⬆️  Bump nodejs to 12.5.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 elixir 1.8.1-otp-21
 erlang 21.2.5
+nodejs 12.5.0

--- a/phoenix_static_buildpack.config
+++ b/phoenix_static_buildpack.config
@@ -1,1 +1,2 @@
 clean_cache=true
+node_version=12.5.0


### PR DESCRIPTION
- [x] ⬆️  Bump nodejs to 12.5.0

right now the nodejs version is: `Node 6.9.2`

and this PR #440 have an update that demands at least `8.9.0`