### PR TITLE
Expand relative markdown links

### DIFF
--- a/lib/tilex/markdown.ex
+++ b/lib/tilex/markdown.ex
@@ -1,21 +1,23 @@
 defmodule Tilex.Markdown do
   alias Tilex.Cache
 
+  @base_url Application.get_env(:tilex, :canonical_domain)
+
   def to_html_live(markdown) do
     markdown
     |> Earmark.as_html!(%Earmark.Options{code_class_prefix: "language-"})
     |> HtmlSanitizeEx.markdown_html()
+    |> expand_relative_links(@base_url)
     |> String.trim()
   end
 
   def to_html(markdown) do
     Cache.cache(markdown, fn ->
       to_html_live(markdown)
-      # |> expand_relative_links("https://til.hashrocket.com")
     end)
   end
 
-  def expand_relative_links(dom, url) do
+  defp expand_relative_links(dom, url) do
     dom
     |> Floki.parse()
     |> Floki.map(fn tuple -> expand_relative_link(tuple, url) end)

--- a/test/lib/tilex/markdown_test.exs
+++ b/test/lib/tilex/markdown_test.exs
@@ -4,86 +4,80 @@ defmodule Lib.Tilex.MarkdownTest do
   alias Tilex.Markdown
 
   @to_html_data [
-    {"", ""},
-    {"Some text", "<p>Some text</p>"},
-    {"```\nsome code block\n```", "<pre><code class=\" language-\">some code block</code></pre>"},
-    {"```elixir\ndefmodule Foo do\nend\n```", "<pre><code class=\"elixir language-elixir\">defmodule Foo do\nend</code></pre>"},
-    {"<script>alert('A great grasshopper!')</script>", "<p>alert(‘A great grasshopper!’)</p>"},
-    {"Some http://link.com?foo=bar", "<p>Some http://link.com?foo=bar</p>"},
-    {"some [Link](http://link.com?foo=bar)", "<p>some <a href=\"http://link.com?foo=bar\">Link</a></p>"},
-    {"some [Relative Link](/link.com?foo=bar)", "<p>some <a href=\"/link.com?foo=bar\">Relative Link</a></p>"},
-    {"```\n# some http://link.com?foo=bar\n```", "<pre><code class=\" language-\"># some http://link.com?foo=bar</code></pre>"},
+    %{
+      input: "",
+      expected: ""
+    },
+    %{
+      input: "Some text",
+      expected: "<p>Some text</p>"
+    },
+    %{
+      input: "```\nsome code block\n```",
+      expected: "<pre><code class=\" language-\">some code block</code></pre>"
+    },
+    %{
+      input: "```elixir\ndefmodule Foo do\nend\n```",
+      expected: "<pre><code class=\"elixir language-elixir\">defmodule Foo do\nend</code></pre>"
+    },
+    %{
+      input: "<script>alert('A great grasshopper!')</script>",
+      expected: "<p>alert(‘A great grasshopper!’)</p>"
+    },
+    %{
+      input: "Some http://link.com?foo=bar",
+      expected: "<p>Some http://link.com?foo=bar</p>"
+    },
+    %{
+      input: "Some /link.com?foo=bar",
+      expected: "<p>Some /link.com?foo=bar</p>"
+    },
+    %{
+      input: "some [Link](http://link.com?foo=bar)",
+      expected: "<p>some <a href=\"http://link.com?foo=bar\">Link</a></p>"
+    },
+    %{
+      input: "some [Relative Link](/link.com?foo=bar)",
+      expected:
+        "<p>some <a href=\"https://til.hashrocket.com/link.com?foo=bar\">Relative Link</a></p>"
+    },
+    %{
+      input: "some <a href=\"http://link.com?foo=bar\">Link</a>",
+      expected: "<p>some <a href=\"http://link.com?foo=bar\">Link</a></p>"
+    },
+    %{
+      input: "some <a href=\"/link.com?foo=bar\">Link</a>",
+      expected: "<p>some <a href=\"https://til.hashrocket.com/link.com?foo=bar\">Link</a></p>"
+    },
+    %{
+      input: "```\n# some http://link.com?foo=bar\n```",
+      expected: "<pre><code class=\" language-\"># some http://link.com?foo=bar</code></pre>"
+    },
+    %{
+      input: "```\n# some /link.com?foo=bar\n```",
+      expected: "<pre><code class=\" language-\"># some /link.com?foo=bar</code></pre>"
+    }
   ]
 
   describe "to_html_live/1" do
-    for {value, expected} <- @to_html_data do
-      @value value
+    for %{input: input, expected: expected} <- @to_html_data do
+      @input input
       @expected expected
 
-      test "converts markdown '#{inspect(@value)}' into html" do
-        assert Markdown.to_html_live(@value) == @expected
+      test "converts markdown '#{inspect(@input)}' into html" do
+        assert Markdown.to_html_live(@input) == @expected
       end
     end
   end
 
   describe "to_html/1" do
-    for {value, expected} <- @to_html_data do
-      @value value
+    for %{input: input, expected: expected} <- @to_html_data do
+      @input input
       @expected expected
 
-      test "converts markdown '#{inspect(@value)}' into html" do
-        assert Markdown.to_html(@value) == @expected
+      test "converts markdown '#{inspect(@input)}' into html" do
+        assert Markdown.to_html(@input) == @expected
       end
-    end
-
-    test "removes script tags" do
-      html = Markdown.to_html("<script>alert('A great grasshopper!')</script>")
-
-      assert html == "<p>alert(‘A great grasshopper!’)</p>"
-    end
-  end
-
-  describe "expand_relative_links/2" do
-    test "works" do
-      html =
-        """
-          <a href='/relative' id='1'>my relatives</a>
-        """
-        |> Markdown.expand_relative_links("https://til.hashrocket.com")
-
-      expected = """
-        <a href="https://til.hashrocket.com/relative" id="1">my relatives</a>
-      """
-
-      assert html == String.trim(expected)
-    end
-
-    test "already expanded http" do
-      html =
-        """
-          <a href='http://elixirdocs.org/strings' id='1'>my relatives</a>
-        """
-        |> Markdown.expand_relative_links("https://til.hashrocket.com")
-
-      expected = """
-        <a href="http://elixirdocs.org/strings" id="1">my relatives</a>
-      """
-
-      assert html == String.trim(expected)
-    end
-
-    test "already expanded https" do
-      html =
-        """
-          <a href='https://elixirdocs.org/strings' id='1'>my relatives</a>
-        """
-        |> Markdown.expand_relative_links("https://til.hashrocket.com")
-
-      expected = """
-        <a href="https://elixirdocs.org/strings" id="1">my relatives</a>
-      """
-
-      assert html == String.trim(expected)
     end
   end
 end

--- a/test/lib/tilex/markdown_test.exs
+++ b/test/lib/tilex/markdown_test.exs
@@ -1,13 +1,43 @@
 defmodule Lib.Tilex.MarkdownTest do
   use ExUnit.Case, async: true
 
+  alias Tilex.Markdown
+
+  @to_html_data [
+    {"", ""},
+    {"Some text", "<p>Some text</p>"},
+    {"```\nsome code block\n```", "<pre><code class=\" language-\">some code block</code></pre>"},
+    {"```elixir\ndefmodule Foo do\nend\n```", "<pre><code class=\"elixir language-elixir\">defmodule Foo do\nend</code></pre>"},
+    {"<script>alert('A great grasshopper!')</script>", "<p>alert(‘A great grasshopper!’)</p>"},
+    {"Some http://link.com?foo=bar", "<p>Some http://link.com?foo=bar</p>"},
+    {"some [Link](http://link.com?foo=bar)", "<p>some <a href=\"http://link.com?foo=bar\">Link</a></p>"},
+    {"some [Relative Link](/link.com?foo=bar)", "<p>some <a href=\"/link.com?foo=bar\">Relative Link</a></p>"},
+    {"```\n# some http://link.com?foo=bar\n```", "<pre><code class=\" language-\"># some http://link.com?foo=bar</code></pre>"},
+  ]
+
+  describe "to_html_live/1" do
+    for {value, expected} <- @to_html_data do
+      @value value
+      @expected expected
+
+      test "converts markdown '#{inspect(@value)}' into html" do
+        assert Markdown.to_html_live(@value) == @expected
+      end
+    end
+  end
+
   describe "to_html/1" do
+    for {value, expected} <- @to_html_data do
+      @value value
+      @expected expected
+
+      test "converts markdown '#{inspect(@value)}' into html" do
+        assert Markdown.to_html(@value) == @expected
+      end
+    end
+
     test "removes script tags" do
-      html =
-        """
-        <script>alert('A great grasshopper!')</script>
-        """
-        |> Tilex.Markdown.to_html()
+      html = Markdown.to_html("<script>alert('A great grasshopper!')</script>")
 
       assert html == "<p>alert(‘A great grasshopper!’)</p>"
     end
@@ -19,7 +49,7 @@ defmodule Lib.Tilex.MarkdownTest do
         """
           <a href='/relative' id='1'>my relatives</a>
         """
-        |> Tilex.Markdown.expand_relative_links("https://til.hashrocket.com")
+        |> Markdown.expand_relative_links("https://til.hashrocket.com")
 
       expected = """
         <a href="https://til.hashrocket.com/relative" id="1">my relatives</a>
@@ -33,7 +63,7 @@ defmodule Lib.Tilex.MarkdownTest do
         """
           <a href='http://elixirdocs.org/strings' id='1'>my relatives</a>
         """
-        |> Tilex.Markdown.expand_relative_links("https://til.hashrocket.com")
+        |> Markdown.expand_relative_links("https://til.hashrocket.com")
 
       expected = """
         <a href="http://elixirdocs.org/strings" id="1">my relatives</a>
@@ -47,7 +77,7 @@ defmodule Lib.Tilex.MarkdownTest do
         """
           <a href='https://elixirdocs.org/strings' id='1'>my relatives</a>
         """
-        |> Tilex.Markdown.expand_relative_links("https://til.hashrocket.com")
+        |> Markdown.expand_relative_links("https://til.hashrocket.com")
 
       expected = """
         <a href="https://elixirdocs.org/strings" id="1">my relatives</a>


### PR DESCRIPTION
- [x] ✨ Enable expand relative links on Markdown
- [x] ✅ Add some Markdown tests for to_html_live and to_html

relates to this issue but it does not solve it yet: https://github.com/hashrocket/tilex/issues/430