### PR TITLE
Add consulting channel

### DIFF
--- a/lib/mix/tasks/tilex/add_consulting_channel.ex
+++ b/lib/mix/tasks/tilex/add_consulting_channel.ex
@@ -1,0 +1,13 @@
+defmodule Mix.Tasks.Tilex.AddConsultingChannel do
+  use Mix.Task
+
+  @shortdoc "Add consulting channel"
+  @moduledoc """
+    Adds a consulting channel.
+  """
+
+  def run(_) do
+    Mix.Task.run("app.start")
+    Tilex.Repo.insert!(%Tilex.Channel{name: "consulting", twitter_hashtag: "consulting"})
+  end
+end


### PR DESCRIPTION
Adds a mix task to make a consulting channel.

I ran this on the review app and the channel's posts page can be viewed at `/consulting`. The command to execute this task in different environments is:

```
$ heroku run "POOL_SIZE=2 mix tilex.add_consulting_channel" --app <your-heroku-app>
```