### PR TITLE
Fix auth expired redirect loop

### DIFF
--- a/lib/tilex/auth/error_handler.ex
+++ b/lib/tilex/auth/error_handler.ex
@@ -8,7 +8,7 @@ defmodule Tilex.Auth.ErrorHandler do
   @impl Guardian.Plug.ErrorHandler
   def auth_error(conn, {_failure_type, _reason}, _opts) do
     conn
-    |> put_status(302)
+    |> Tilex.Auth.Guardian.Plug.sign_out()
     |> put_flash(:info, "Authentication required")
     |> redirect(to: post_path(conn, :index))
   end

--- a/lib/tilex_web/controllers/post_controller.ex
+++ b/lib/tilex_web/controllers/post_controller.ex
@@ -14,6 +14,9 @@ defmodule TilexWeb.PostController do
     when action in ~w(new create edit update)a
   )
 
+  @behaviour Guardian.Plug.ErrorHandler
+
+  @impl Guardian.Plug.ErrorHandler
   def auth_error(conn, {_failure_type, _reason}, _opts) do
     conn
     |> put_status(302)

--- a/lib/tilex_web/controllers/stats_controller.ex
+++ b/lib/tilex_web/controllers/stats_controller.ex
@@ -3,14 +3,15 @@ defmodule TilexWeb.StatsController do
 
   alias Tilex.Stats
 
-  alias Guardian.Plug, as: Guardian
-
   plug(
-    Guardian.EnsureAuthenticated,
+    Guardian.Plug.EnsureAuthenticated,
     [error_handler: __MODULE__]
     when action in ~w(developer)a
   )
 
+  @behaviour Guardian.Plug.ErrorHandler
+
+  @impl Guardian.Plug.ErrorHandler
   def auth_error(conn, {_failure_type, _reason}, _opts) do
     conn
     |> put_status(302)

--- a/test/lib/tilex/auth/error_handler_test.exs
+++ b/test/lib/tilex/auth/error_handler_test.exs
@@ -1,0 +1,28 @@
+defmodule Tilex.Auth.ErrorHandlerTest do
+  use TilexWeb.ConnCase, async: true
+
+  alias Tilex.Auth.ErrorHandler
+
+  setup %{conn: conn} do
+    new_conn =
+      conn
+      |> Plug.Test.init_test_session(%{})
+      |> Phoenix.ConnTest.fetch_flash()
+
+    [conn: new_conn]
+  end
+
+  describe "auth_error/3" do
+    test "redirects to root with 302", %{conn: conn} do
+      assert conn
+             |> ErrorHandler.auth_error({:oauth_failure, :token_expired}, [])
+             |> redirected_to(302) == "/"
+    end
+
+    test "adds a flash message with error", %{conn: conn} do
+      assert conn
+             |> ErrorHandler.auth_error({:oauth_failure, :token_expired}, [])
+             |> Phoenix.ConnTest.get_flash() == %{"info" => "Authentication required"}
+    end
+  end
+end


### PR DESCRIPTION
- [x] 🔥 Clear guardian session on ErrorHandler
- [x] Add missing Guardian ErrorHandler behaviour/impl

This PR avoids the infinite loop to root '/' when the session is
invalid.

## Steps to reproduce the error locally

1. start the app
2. http://localhost:4000/admin
3. authenticate via oauth
4. quits the app
5. advance local time to some years ahead
6. starts the app again
7. visit http://localhost:4000/ to see the infinite redirect loop

<img width="524" alt="Screen Shot 2019-07-05 at 2 36 45 PM" src="https://user-images.githubusercontent.com/1071893/60742069-cc3cce00-9f39-11e9-9541-6cf83ab69bb5.png">

## Before

```
[info] GET /
[debug] Processing with TilexWeb.PostController.index/2
  Parameters: %{}
  Pipelines: [:browser, :browser_auth]
[info] Sent 302 in 98ms
[info] GET /
[debug] Processing with TilexWeb.PostController.index/2
  Parameters: %{}
  Pipelines: [:browser, :browser_auth]
[info] Sent 302 in 512µs
[info] GET /
[debug] Processing with TilexWeb.PostController.index/2
  Parameters: %{}
  Pipelines: [:browser, :browser_auth]
[info] Sent 302 in 844µs
```

## After

```
[info] GET /
[debug] Processing with TilexWeb.PostController.index/2
  Parameters: %{}
  Pipelines: [:browser, :browser_auth]
[info] Sent 302 in 650µs
[info] GET /
[debug] Processing with TilexWeb.PostController.index/2
  Parameters: %{}
  Pipelines: [:browser, :browser_auth]
[debug] QUERY OK source="posts" db=9.9ms decode=1.4ms queue=2.4ms
SELECT p0."id", p0."title", p0."body", p0."slug", p0."likes", p0."max_likes", p0."tweeted_at", p0."channel_id", p0."developer_id", p0."inserted_at", p0."updated_at", c1."id", c1."name", c1."twitter_hashtag", c1."inserted_at", c1."updated_at", d2."id", d2."email", d2."username", d2."twitter_handle", d2."admin", d2."editor", d2."inserted_at", d2."updated_at" FROM "posts" AS p0 INNER JOIN "channels" AS c1 ON c1."id" = p0."channel_id" INNER JOIN "developers" AS d2 ON d2."id" = p0."developer_id" ORDER BY p0."inserted_at" DESC LIMIT $1 OFFSET $2 [51, 0]
<no file>:2: warning: Failed to find closing <pre>
[info] Sent 200 in 251ms
```