### PR TITLE
Fix tracking pixel mime-type

### DIFF
--- a/lib/tilex_web/controllers/pixel_controller.ex
+++ b/lib/tilex_web/controllers/pixel_controller.ex
@@ -6,6 +6,7 @@ defmodule TilexWeb.PixelController do
 
     conn
     |> put_resp_header("cache-control", "no-cache, no-store, must-revalidate")
+    |> put_resp_content_type("application/javascript")
     |> send_resp(:ok, "")
   end
 end


### PR DESCRIPTION
Firefox complained about the pixel request missing a response mime type. This PR adds a mime type of a JavaScript file to address this issue.

<img width="1485" alt="image" src="https://user-images.githubusercontent.com/551858/63467698-a7d67b80-c42b-11e9-8bfc-8ccbd65220e8.png">
