### PR TITLE
[Elixir 1.9] Migrate Mix.Config -> Config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,9 +1,9 @@
 # This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
+# and its dependencies with the aid of the Config module.
 #
 # This configuration file is loaded before any dependency and
 # is restricted to this project.
-use Mix.Config
+import Config
 
 # General application configuration
 config :tilex, ecto_repos: [Tilex.Repo]

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 # For development, we disable any cache and enable
 # debugging and code reloading.

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 # For production, we configure the host to read the PORT
 # from the system environment. Therefore, you will need

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 # We don't run a server during test. If one is required,
 # you can enable the server option below.


### PR DESCRIPTION
> A new `Config` module has been added to Elixir. The previous configuration API, `Mix.Config`, was part of the Mix build tool. But since releases provide runtime configuration and Mix is not included in releases, we ported the `Mix.Config` API to Elixir. In other words, use `Mix.Config` has been soft-deprecated in favor of `import Config`

Read more in the CHANGELOG:
https://github.com/elixir-lang/elixir/blob/v1.9/CHANGELOG.md#configuration-overhaul