### PR TITLE
Clean up Earmark warnings

### DIFF
--- a/lib/tilex/markdown.ex
+++ b/lib/tilex/markdown.ex
@@ -4,8 +4,13 @@ defmodule Tilex.Markdown do
   @base_url Application.get_env(:tilex, :canonical_domain)
 
   def to_html_live(markdown) do
+    earmark_options = %Earmark.Options{
+      code_class_prefix: "language-",
+      pure_links: false
+    }
+
     markdown
-    |> Earmark.as_html!(%Earmark.Options{code_class_prefix: "language-"})
+    |> Earmark.as_html!(earmark_options)
     |> HtmlSanitizeEx.markdown_html()
     |> expand_relative_links(@base_url)
     |> String.trim()

--- a/lib/tilex_web/views/layout_view.ex
+++ b/lib/tilex_web/views/layout_view.ex
@@ -61,7 +61,9 @@ defmodule TilexWeb.LayoutView do
   def twitter_description(%Tilex.Post{} = post) do
     markdown = Tilex.Post.twitter_description(post)
 
-    with {:ok, html, _} <- Earmark.as_html(markdown),
+    earmark_options = %Earmark.Options{pure_links: false}
+
+    with {:ok, html, _} <- Earmark.as_html(markdown, earmark_options),
          text <- Floki.text(html) do
       text
     else


### PR DESCRIPTION
This is the warning it cleans up:

```
<no file>:1: deprecation: The string "https://github.com/pragdave/earmark" will be rendered as a link if the option `pure_links` is enabled.
This will be the case by default in version 1.4.
Disable the option explicitly with `false` to avoid this message.
```

You will see it if you run `mix test`