### PR TITLE
Support Observer on Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: MIX_ENV=prod mix phx.server
+web: MIX_ENV=prod elixir --cookie $OTP_COOKIE --name server@127.0.0.1 --erl '-kernel inet_dist_listen_min 9000' --erl '-kernel inet_dist_listen_max 9000' -S mix phx.server

--- a/app.json
+++ b/app.json
@@ -36,6 +36,11 @@
     },
     "DATE_DISPLAY_TZ": {
       "required": true
+    },
+    "OTP_COOKIE": {
+      "description": "A cookie used for remote node connections",
+      "generator": "secret",
+      "required": true
     }
   },
   "formation": {},


### PR DESCRIPTION
Based on:

- https://jclem.net/posts/2019-08-21-observing-phoenix-on-heroku/
- https://github.com/jclem/phoenix-template

To use follow these steps:
1. In one terminal forward the required ports to the your local machine using the following command:

```bash
heroku ps:forward 9001:4369,9000 -a tilex-staging-pr-555
```

2. In another terminal get the `OTP_COOKIE` from the config on the dyno:

```bash
export OTP_COOKIE=$(heroku config -a tilex-staging-pr-555 | grep OTP_COOKIE | sed 's/OTP_COOKIE://' | xargs)
```

3. Then use it to open an `iex` session against the forwarded port on the local machine:

```bash
env ERL_EPMD_PORT=9001 iex --cookie $OTP_COOKIE --name console@127.0.0.1
```

4. Run `:observer` 

```elixir
iex> :observer.start()
```