### PR TITLE
Use ETS for Rate Limiter

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -41,6 +41,11 @@ config :tilex,
        :rate_limiter_time_period_minutes,
        System.get_env("RATE_LIMIT_TIME_PERIOD_MINUTES") || 1
 
+config :tilex,
+       :rate_limiter_cleanup_interval,
+       # every 10 hours
+       System.get_env("RATE_LIMIT_CLEANUP_INTERVAL") || 10 * 60 * 60_000
+
 config :tilex, :date_time_module, DateTime
 
 # Configures Elixir's Logger

--- a/lib/tilex/rate_limiter.ex
+++ b/lib/tilex/rate_limiter.ex
@@ -5,38 +5,53 @@ defmodule Tilex.RateLimiter do
   @date_time_module Application.get_env(:tilex, :date_time_module)
   @limit Application.get_env(:tilex, :rate_limiter_requests_per_time_period)
   @time_period_minutes Application.get_env(:tilex, :rate_limiter_time_period_minutes)
-
-  # Client ----------------------------------------------
+                       |> Timex.Duration.from_minutes()
+  @table_name :rate_limiter_lookup
 
   def start_link do
     GenServer.start_link(__MODULE__, [], name: @name)
   end
 
+  @spec check(ip: String.t()) :: boolean()
   def check(ip: ip) do
-    GenServer.call(@name, {:check_ip, ip})
-  end
+    request_times = lookup_ip(ip)
+    current_time = @date_time_module.utc_now()
+    recent_request_times = filter_recent_request_times(current_time, request_times)
+    current_requests = [current_time | recent_request_times]
 
-  # Server ----------------------------------------------
+    :ets.insert(@table_name, {ip, current_requests})
+
+    length(current_requests) <= @limit
+  end
 
   @impl true
   def init(_) do
+    create_table()
     {:ok, %{}}
   end
 
-  @impl true
-  def handle_call({:check_ip, ip}, _from, state) do
-    request_times = state |> Map.get(ip, [])
-    current_time = @date_time_module.utc_now()
-    end_time = Timex.subtract(current_time, Timex.Duration.from_minutes(@time_period_minutes))
+  defp create_table do
+    :ets.new(@table_name, [
+      :set,
+      :public,
+      :named_table,
+      read_concurrency: true,
+      write_concurrency: true
+    ])
+  end
 
-    recent_request_times =
-      Enum.filter(request_times, fn time ->
-        Timex.between?(time, end_time, current_time, inclusive: true)
-      end)
+  defp lookup_ip(ip) do
+    case :ets.lookup(@table_name, ip) do
+      [{^ip, requests}] -> requests
+      _ -> []
+    end
+  end
 
-    current_requests = [current_time | recent_request_times]
-    new_state = Map.put(state, ip, current_requests)
+  defp filter_recent_request_times(current_time, request_times) do
+    end_time = Timex.subtract(current_time, @time_period_minutes)
 
-    {:reply, length(current_requests) <= @limit, new_state}
+    Enum.filter(request_times, fn time ->
+      Timex.between?(time, end_time, current_time, inclusive: true)
+    end)
   end
 end


### PR DESCRIPTION
## Use ETS for Rate Limiter
This removes the bottleneck of one process serving as a gateway for all `/like` requests and is inspired by Chris McCords' Programming Phoenix >= 1.4:

> “If all requests depend on a single process for caching, said process will become a bottleneck and hurt the user experience.”

&mdash; Excerpt From: Chris McCord, Bruce Tate, José Valim. “Programming Phoenix ≥ 1.4”
Chapter 12: OTP, Section: Designing an Information System with OTP

ETS allows concurrent reads and writes, and is very fast, so it should allow a higher throughput. Also it is good to set an example to other developers from OTP system design perspective.

## Periodically Clean Up Rate Limiter Table
This PR also introduces a periodical cleanup of the Rate Limiter table to ensure the memory use is in check. It is likely not an issue, since the Rate Limiter is only used for likes, but still good to have in case someone deploys this on a platform that allows long running process (read everything but Heroku).

The default cleanup time is every 10 hours, which I think is reasonable.