### PR TITLE
Hide the flashes after 10 seconds

### DIFF
--- a/assets/js/tilex.js
+++ b/assets/js/tilex.js
@@ -1,6 +1,15 @@
 import PostForm from './post_form';
 
 $(function() {
+  $('#flash p').on(
+    'load',
+    (function() {
+      setTimeout(function() {
+        $('#flash p').fadeOut(200);
+      }, 10000);
+    })()
+  );
+
   $(document.body).on('click', '#flash p', function(e) {
     e.preventDefault();
     $(this).fadeOut(200);


### PR DESCRIPTION
A piece of feedback I've heard about TIL is that the "you signed in" flash covers up our very minimal toolbar until you click it, making it hard for new users to know what do do after authentication.

This change fades out the flash after ten seconds.