### PR TITLE
Use authorized post parameters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,12 @@ jobs:
       - run: mix phx.digest
       - run: mix format --check-formatted
       - run: mix credo
+      - run:
+          name: "Setup environment variables"
+          command: |
+            echo 'export DATE_DISPLAY_TZ=America/Chicago' >> $BASH_ENV
+            echo 'export MIX_ENV=test' >> $BASH_ENV
+            echo 'export TZ=America/Chicago' >> $BASH_ENV
       - run: mix coveralls.circle
       - store_artifacts:
           path: /home/circleci/tilex/screenshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,6 @@ jobs:
             echo 'export DATE_DISPLAY_TZ=America/Chicago' >> $BASH_ENV
             echo 'export MIX_ENV=test' >> $BASH_ENV
             echo 'export TZ=America/Chicago' >> $BASH_ENV
-      - run: mix coveralls.circle
+      - run: if [ "$COVERALLS_REPO_TOKEN" ]; then mix coveralls.circle; else mix test; fi
       - store_artifacts:
           path: /home/circleci/tilex/screenshots

--- a/lib/tilex_web/controllers/post_controller.ex
+++ b/lib/tilex_web/controllers/post_controller.ex
@@ -108,9 +108,8 @@ defmodule TilexWeb.PostController do
     developer = Plug.current_resource(conn)
 
     changeset =
-      %Post{}
-      |> Map.put(:developer_id, developer.id)
-      |> Post.changeset(post_params)
+      post_params
+      |> Post.create_changeset(developer_id: developer.id)
 
     case Repo.insert(changeset) do
       {:ok, post} ->
@@ -165,7 +164,9 @@ defmodule TilexWeb.PostController do
           Repo.get_by!(Post, slug: conn.assigns.slug)
       end
 
-    changeset = Post.changeset(post, post_params)
+    changeset =
+      post
+      |> Post.update_changeset(post_params)
 
     case Repo.update(changeset) do
       {:ok, post} ->

--- a/lib/tilex_web/models/post.ex
+++ b/lib/tilex_web/models/post.ex
@@ -12,12 +12,7 @@ defmodule Tilex.Post do
   def title_max_chars, do: @title_max_chars
 
   @params ~w(title body developer_id channel_id likes max_likes)a
-  @user_editable_params ~w(title body channel_id)a
   def permitted_params, do: @params
-  def required_create_params, do: @user_editable_params
-  def required_update_params, do: @user_editable_params
-  def permitted_update_params, do: @user_editable_params
-  def permitted_create_params, do: @user_editable_params
   def required_params, do: @params
 
   schema "posts" do
@@ -85,25 +80,25 @@ defmodule Tilex.Post do
     |> hd
   end
 
-  def create_changeset(params, changes) do
+  def create_changeset(params, developer_id: developer_id) do
     %__MODULE__{}
-    |> cast(params, permitted_create_params())
-    |> validate_required(required_create_params())
+    |> cast(params, ~w(title body channel_id)a)
+    |> change(developer_id: developer_id)
+    |> add_slug
+    |> validate_required(~w(title body channel_id developer_id)a)
     |> validate_length(:title, max: title_max_chars())
     |> validate_length_of_body
     |> validate_number(:likes, greater_than: 0)
-    |> add_slug
-    |> change(changes)
   end
 
-  def update_changeset(struct, params \\ %{}) do
+  def update_changeset(struct, params) do
     struct
-    |> cast(params, permitted_update_params())
-    |> validate_required(required_update_params())
+    |> cast(params, ~w(title body channel_id)a)
+    |> add_slug
+    |> validate_required(~w(title body channel_id)a)
     |> validate_length(:title, max: title_max_chars())
     |> validate_length_of_body
     |> validate_number(:likes, greater_than: 0)
-    |> add_slug
   end
 
   defp add_slug(changeset) do

--- a/lib/tilex_web/models/post.ex
+++ b/lib/tilex_web/models/post.ex
@@ -12,7 +12,12 @@ defmodule Tilex.Post do
   def title_max_chars, do: @title_max_chars
 
   @params ~w(title body developer_id channel_id likes max_likes)a
+  @user_editable_params ~w(title body channel_id)a
   def permitted_params, do: @params
+  def required_create_params, do: @user_editable_params
+  def required_update_params, do: @user_editable_params
+  def permitted_update_params, do: @user_editable_params
+  def permitted_create_params, do: @user_editable_params
   def required_params, do: @params
 
   schema "posts" do
@@ -78,6 +83,27 @@ defmodule Tilex.Post do
     post.body
     |> String.split("\n")
     |> hd
+  end
+
+  def create_changeset(params, changes) do
+    %__MODULE__{}
+    |> cast(params, permitted_create_params())
+    |> validate_required(required_create_params())
+    |> validate_length(:title, max: title_max_chars())
+    |> validate_length_of_body
+    |> validate_number(:likes, greater_than: 0)
+    |> add_slug
+    |> change(changes)
+  end
+
+  def update_changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, permitted_update_params())
+    |> validate_required(required_update_params())
+    |> validate_length(:title, max: title_max_chars())
+    |> validate_length_of_body
+    |> validate_number(:likes, greater_than: 0)
+    |> add_slug
   end
 
   defp add_slug(changeset) do

--- a/test/controllers/post_controller_test.exs
+++ b/test/controllers/post_controller_test.exs
@@ -1,5 +1,7 @@
 defmodule Tilex.PostControllerTest do
   use TilexWeb.ConnCase, async: true
+  alias Tilex.Factory
+  alias Tilex.Auth
 
   test "lists all entries on index", %{conn: conn} do
     conn = get(conn, post_path(conn, :index))
@@ -29,5 +31,178 @@ defmodule Tilex.PostControllerTest do
   test "throws 404 with slug less than 10 characters", %{conn: conn} do
     conn = get(conn, post_path(conn, :edit, "123456789"))
     assert html_response(conn, 404)
+  end
+
+  describe "when authenticated" do
+    setup :authenticated_conn
+
+    test "user can't set developer_id when creating posts", %{
+      conn: conn,
+      current_user: current_user,
+      channel: channel
+    } do
+      other_user = Factory.insert!(:developer, username: "jackdonaughy")
+
+      params = %{
+        "post" => %{
+          "developer_id" => other_user.id,
+          "title" => "Not Jack's post",
+          "body" => "Hello world",
+          "channel_id" => channel.id
+        }
+      }
+
+      post(conn, post_path(conn, :create, params))
+
+      til =
+        Tilex.Post
+        |> Tilex.Repo.all()
+        |> List.first()
+
+      assert til.developer_id != other_user.id
+      assert til.developer_id == current_user.id
+    end
+
+    test "user can't set likes when creating posts", %{
+      conn: conn,
+      channel: channel
+    } do
+      params = %{
+        "post" => %{
+          "likes" => 99_999,
+          "title" => "Likeable post",
+          "body" => "Hello world",
+          "channel_id" => channel.id
+        }
+      }
+
+      post(conn, post_path(conn, :create, params))
+
+      til =
+        Tilex.Post
+        |> Tilex.Repo.all()
+        |> List.first()
+
+      assert til.likes == 1
+    end
+
+    test "user can't set max_likes when creating posts", %{
+      conn: conn,
+      channel: channel
+    } do
+      params = %{
+        "post" => %{
+          "max_likes" => 99_999,
+          "title" => "Likeable post",
+          "body" => "Hello world",
+          "channel_id" => channel.id
+        }
+      }
+
+      post(conn, post_path(conn, :create, params))
+
+      til =
+        Tilex.Post
+        |> Tilex.Repo.all()
+        |> List.first()
+
+      assert til.max_likes == 1
+    end
+
+    test "user can't set developer_id when updating posts", %{
+      conn: conn,
+      current_user: current_user
+    } do
+      other_user = Factory.insert!(:developer, username: "jackdonaughy")
+
+      til =
+        Factory.insert!(:post,
+          title: "Hi",
+          body: "Body",
+          likes: 1,
+          max_likes: 1
+        )
+
+      params = %{
+        post: %{
+          title: "New Title",
+          developer_id: other_user.id
+        }
+      }
+
+      put(conn, post_path(conn, :update, til.slug, params))
+
+      til =
+        Tilex.Post
+        |> Tilex.Repo.get(til.id)
+
+      assert til.title == "New Title"
+      assert til.developer_id != other_user.id
+      assert til.developer_id == current_user.id
+    end
+
+    test "user can't set likes when updating posts", %{
+      conn: conn
+    } do
+      til =
+        Factory.insert!(:post,
+          title: "Hi",
+          body: "Body",
+          likes: 1,
+          max_likes: 1
+        )
+
+      params = %{
+        post: %{
+          title: "New Title",
+          likes: 1_000_000
+        }
+      }
+
+      put(conn, post_path(conn, :update, til.slug, params))
+
+      til =
+        Tilex.Post
+        |> Tilex.Repo.get(til.id)
+
+      assert til.title == "New Title"
+      assert til.likes == 1
+    end
+
+    test "user can't set max_likes when updating posts", %{
+      conn: conn
+    } do
+      til =
+        Factory.insert!(:post,
+          title: "Hi",
+          body: "Body",
+          likes: 1,
+          max_likes: 1
+        )
+
+      params = %{
+        post: %{
+          title: "New Title",
+          max_likes: 1_000_000
+        }
+      }
+
+      put(conn, post_path(conn, :update, til.slug, params))
+
+      til =
+        Tilex.Post
+        |> Tilex.Repo.get(til.id)
+
+      assert til.title == "New Title"
+      assert til.max_likes == 1
+    end
+  end
+
+  defp authenticated_conn(%{conn: conn}) do
+    current_user = Factory.insert!(:developer, email: "current@example.com", username: "current")
+    channel = Factory.insert!(:channel, name: "git")
+
+    conn = Auth.Guardian.Plug.sign_in(conn, current_user)
+    {:ok, conn: conn, current_user: current_user, channel: channel}
   end
 end


### PR DESCRIPTION
Use the authorized `developer_id` and prevent it from being overwritten by user supplied parameters. Also, prevent users from modify the `developer_id`, `likes`, and `max_likes` when updating a post.