### PR TITLE
Refactor Post Actions and Changeset

### DIFF
--- a/lib/tilex_web/controllers/post_controller.ex
+++ b/lib/tilex_web/controllers/post_controller.ex
@@ -104,15 +104,15 @@ defmodule TilexWeb.PostController do
     |> send_resp(200, Jason.encode!(%{likes: likes}))
   end
 
-  def create(conn, %{"post" => post_params}) do
+  def create(conn, %{"post" => params}) do
     developer = Plug.current_resource(conn)
 
-    strong_params =
-      post_params
-      |> sanitize_params()
+    sanitized_params =
+      params
+      |> post_params()
       |> Map.merge(%{"developer_id" => developer.id})
 
-    changeset = Post.changeset(%Post{}, strong_params)
+    changeset = Post.changeset(%Post{}, sanitized_params)
 
     case Repo.insert(changeset) do
       {:ok, post} ->
@@ -153,7 +153,7 @@ defmodule TilexWeb.PostController do
     |> render("edit.html")
   end
 
-  def update(conn, %{"post" => post_params}) do
+  def update(conn, %{"post" => params}) do
     current_user = Plug.current_resource(conn)
 
     post =
@@ -167,9 +167,9 @@ defmodule TilexWeb.PostController do
           Repo.get_by!(Post, slug: conn.assigns.slug)
       end
 
-    strong_params = sanitize_params(post_params)
+    sanitized_params = post_params(params)
 
-    changeset = Post.changeset(post, strong_params)
+    changeset = Post.changeset(post, sanitized_params)
 
     case Repo.update(changeset) do
       {:ok, post} ->
@@ -229,7 +229,7 @@ defmodule TilexWeb.PostController do
 
   defp robust_page(_params), do: 1
 
-  defp sanitize_params(params) do
+  defp post_params(params) do
     Map.take(params, ["body", "channel_id", "title"])
   end
 end

--- a/lib/tilex_web/models/post.ex
+++ b/lib/tilex_web/models/post.ex
@@ -77,6 +77,8 @@ defmodule Tilex.Post do
     |> validate_length(:title, max: title_max_chars())
     |> validate_length_of_body
     |> validate_number(:likes, greater_than: 0)
+    |> foreign_key_constraint(:channel_id)
+    |> foreign_key_constraint(:developer_id)
   end
 
   defp add_slug(changeset) do

--- a/lib/tilex_web/models/post.ex
+++ b/lib/tilex_web/models/post.ex
@@ -11,9 +11,8 @@ defmodule Tilex.Post do
   @title_max_chars 50
   def title_max_chars, do: @title_max_chars
 
-  @params ~w(title body developer_id channel_id likes max_likes)a
-  def permitted_params, do: @params
-  def required_params, do: @params
+  def permitted_params, do: ~w(body channel_id developer_id likes max_likes title)a
+  def required_params, do: ~w(body channel_id developer_id title)a
 
   schema "posts" do
     field(:title, :string)
@@ -27,16 +26,6 @@ defmodule Tilex.Post do
     belongs_to(:developer, Developer)
 
     timestamps(type: :utc_datetime)
-  end
-
-  def changeset(struct, params \\ %{}) do
-    struct
-    |> cast(params, permitted_params())
-    |> validate_required(required_params())
-    |> validate_length(:title, max: title_max_chars())
-    |> validate_length_of_body
-    |> validate_number(:likes, greater_than: 0)
-    |> add_slug
   end
 
   def slugified_title(title) do
@@ -80,22 +69,11 @@ defmodule Tilex.Post do
     |> hd
   end
 
-  def create_changeset(params, developer_id: developer_id) do
-    %__MODULE__{}
-    |> cast(params, ~w(title body channel_id)a)
-    |> change(developer_id: developer_id)
+  def changeset(post, params \\ %{}) do
+    post
+    |> cast(params, permitted_params())
     |> add_slug
-    |> validate_required(~w(title body channel_id developer_id)a)
-    |> validate_length(:title, max: title_max_chars())
-    |> validate_length_of_body
-    |> validate_number(:likes, greater_than: 0)
-  end
-
-  def update_changeset(struct, params) do
-    struct
-    |> cast(params, ~w(title body channel_id)a)
-    |> add_slug
-    |> validate_required(~w(title body channel_id)a)
+    |> validate_required(required_params())
     |> validate_length(:title, max: title_max_chars())
     |> validate_length_of_body
     |> validate_number(:likes, greater_than: 0)

--- a/lib/tilex_web/models/post.ex
+++ b/lib/tilex_web/models/post.ex
@@ -11,8 +11,8 @@ defmodule Tilex.Post do
   @title_max_chars 50
   def title_max_chars, do: @title_max_chars
 
-  def permitted_params, do: ~w(body channel_id developer_id likes max_likes title)a
-  def required_params, do: ~w(body channel_id developer_id title)a
+  @required_params ~w(body channel_id developer_id title)a
+  @permitted_params @required_params ++ ~w(developer_id likes max_likes)a
 
   schema "posts" do
     field(:title, :string)
@@ -71,9 +71,9 @@ defmodule Tilex.Post do
 
   def changeset(post, params \\ %{}) do
     post
-    |> cast(params, permitted_params())
+    |> cast(params, @permitted_params)
     |> add_slug
-    |> validate_required(required_params())
+    |> validate_required(@required_params)
     |> validate_length(:title, max: title_max_chars())
     |> validate_length_of_body
     |> validate_number(:likes, greater_than: 0)


### PR DESCRIPTION
This change refactors our `Post` model changeset from three functions to one shared function, while exercising tighter control over the parameters we pass to the function.

It builds atop #619, keeping the great tests added there.

Our post controller now features a Rails-style strong parameter whitelisting function called `post_params`. The power to choose most of the correct parameters is being given back to the controller.