### PR TITLE
Replace deprecated `Floki.parse`

### DIFF
--- a/lib/tilex/markdown.ex
+++ b/lib/tilex/markdown.ex
@@ -23,8 +23,9 @@ defmodule Tilex.Markdown do
   end
 
   defp expand_relative_links(dom, url) do
-    dom
-    |> Floki.parse()
+    {:ok, fragment} = Floki.parse_fragment(dom)
+
+    fragment
     |> Floki.map(fn tuple -> expand_relative_link(tuple, url) end)
     |> Floki.raw_html()
   end

--- a/lib/tilex_web/views/layout_view.ex
+++ b/lib/tilex_web/views/layout_view.ex
@@ -63,9 +63,9 @@ defmodule TilexWeb.LayoutView do
 
     earmark_options = %Earmark.Options{pure_links: false}
 
-    with {:ok, html, _} <- Earmark.as_html(markdown, earmark_options),
-         text <- Floki.text(html) do
-      text
+    with {:ok, html, _errors} <- Earmark.as_html(markdown, earmark_options),
+         {:ok, fragment} <- Floki.parse_fragment(html) do
+      Floki.text(fragment)
     else
       _error ->
         markdown


### PR DESCRIPTION
Deprecated: https://hexdocs.pm/floki/Floki.html#parse/1

`Floki.parse_fragment` seems to suit our needs.