### PR TITLE
Move charset to the top of <head>

### DIFF
--- a/lib/tilex_web/templates/error/404.html.eex
+++ b/lib/tilex_web/templates/error/404.html.eex
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta charset="utf-8">
     <title>
       Not Found - Today I Learned
     </title>
 
-    <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     <link href='//fonts.googleapis.com/css?family=Raleway:700,900&display=swap' rel='stylesheet' type='text/css'>

--- a/lib/tilex_web/templates/error/500.html.eex
+++ b/lib/tilex_web/templates/error/500.html.eex
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta charset="utf-8">
     <title>
       Server Error - Today I Learned
     </title>
 
-    <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     <link href='//fonts.googleapis.com/css?family=Raleway:700,900&display=swap' rel='stylesheet' type='text/css'>

--- a/lib/tilex_web/templates/layout/app.html.eex
+++ b/lib/tilex_web/templates/layout/app.html.eex
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta charset="utf-8">
     <title>
       <%= page_title(assigns) %> - Today I Learned
     </title>
@@ -29,7 +30,6 @@
 
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/atom-one-dark.min.css">
 
-    <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     <link rel="stylesheet" href="<%= static_url(@conn, "/css/app.css") %>">


### PR DESCRIPTION
See #620 

Per MDN:

The <meta> element declaring the encoding must be inside the <head>
element and within the first 1024 bytes of the HTML as some browsers
only look at those bytes before choosing an encoding.

Source: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta