### PR TITLE
Remove redundant MIME type

### DIFF
--- a/lib/tilex_web/templates/layout/app.html.eex
+++ b/lib/tilex_web/templates/layout/app.html.eex
@@ -136,7 +136,7 @@
       </ul>
     </nav>
 
-    <script type="text/javascript">
+    <script>
       window.Tilex = window.Tilex || {};
       window.Tilex.clientConfig = {
         editor: '<%= editor_preference(@conn) %>',
@@ -147,7 +147,7 @@
     <script src="<%= static_url(@conn, "/js/app.js") %>"></script>
 
     <%= if ga_identifier() do %>
-      <script type="text/javascript">
+      <script>
         (function(i, s, o, g, r, a, m) {
           i['GoogleAnalyticsObject'] = r;
           (i[r] =


### PR DESCRIPTION
See #620:

Per MDN:

Omitted or a JavaScript MIME type: This indicates the script is
JavaScript. The HTML5 specification urges authors to omit the attribute
rather than provide a redundant MIME type. In earlier browsers, this
identified the scripting language of the embedded or imported (via the
src attribute) code. JavaScript MIME types are listed in the
specification.

Source:

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script