### PR TITLE
Add Byline and Post Time Tag

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -29,6 +29,7 @@ config :tilex, :auth_controller, Test.AuthController
 config :tilex, :slack_notifier, Test.Notifications.Notifiers.Slack
 config :tilex, :twitter_notifier, Test.Notifications.Notifiers.Twitter
 config :tilex, :date_time_module, Tilex.DateTimeMock
+config :tilex, :date_display_tz, "America/Chicago"
 
 config :tilex, :async_feature_test, System.get_env("ASYNC_FEATURE_TEST") == "yes"
 

--- a/lib/tilex_web/templates/shared/post.html.eex
+++ b/lib/tilex_web/templates/shared/post.html.eex
@@ -13,15 +13,17 @@
            data-via= "<%= Tilex.Developer.twitter_handle(@post.developer) %>"
            data-hashtags= "<%= @post.channel.twitter_hashtag %>"
            data-url= "<%= post_url(@conn, :show, @post) %>">
-          Tweet
+           Tweet
         </a>
       <% end %>
 
       <footer>
-        <p>
+        <p class="byline">
           <%= link(@post.developer.username, to: developer_path(@conn, :show, @post.developer)) %>
           <br/>
-          <%= link(display_date(@post), to: post_path(@conn, :show, @post), class: "post__permalink") %>
+          <time datetime="<%= @post.inserted_at %>">
+            <%= link(display_date(@post), to: post_path(@conn, :show, @post), class: "post__permalink") %>
+          </time>
         </p>
       </footer>
     </div>

--- a/lib/tilex_web/templates/shared/post.html.eex
+++ b/lib/tilex_web/templates/shared/post.html.eex
@@ -13,7 +13,7 @@
            data-via= "<%= Tilex.Developer.twitter_handle(@post.developer) %>"
            data-hashtags= "<%= @post.channel.twitter_hashtag %>"
            data-url= "<%= post_url(@conn, :show, @post) %>">
-           Tweet
+          Tweet
         </a>
       <% end %>
 

--- a/lib/tilex_web/views/shared_view.ex
+++ b/lib/tilex_web/views/shared_view.ex
@@ -5,16 +5,9 @@ defmodule TilexWeb.SharedView do
   alias Timex.Timezone
 
   def display_date(post) do
-    inserted_at =
-      case Application.get_env(:tilex, :date_display_tz) do
-        x when x in [nil, ""] ->
-          post.inserted_at
-
-        tz ->
-          Timezone.convert(post.inserted_at, tz)
-      end
-
-    Timex.format!(inserted_at, "%B %-e, %Y", :strftime)
+    post.inserted_at
+    |> maybe_convert_to_display_tz()
+    |> Timex.format!("%B %-e, %Y", :strftime)
   end
 
   def pluralize(1, object), do: "1 #{object}"
@@ -32,5 +25,15 @@ defmodule TilexWeb.SharedView do
   def post_creator_or_admin?(conn, post) do
     Plug.current_resource(conn) &&
       (post.developer == Plug.current_resource(conn) || Plug.current_resource(conn).admin)
+  end
+
+  defp maybe_convert_to_display_tz(timestamp) do
+    case Application.get_env(:tilex, :date_display_tz) do
+      setting when setting in [nil, ""] ->
+        timestamp
+
+      tz ->
+        Timezone.convert(timestamp, tz)
+    end
   end
 end

--- a/lib/tilex_web/views/shared_view.ex
+++ b/lib/tilex_web/views/shared_view.ex
@@ -17,12 +17,13 @@ defmodule TilexWeb.SharedView do
     Timex.format!(inserted_at, "%B %-e, %Y", :strftime)
   end
 
+  def pluralize(1, object), do: "1 #{object}"
+
+  def pluralize(count, object), do: "#{count} #{object}s"
+
   def rss_date(post) do
     Timex.format!(post.inserted_at, "%a, %d %b %Y %H:%M:%S GMT", :strftime)
   end
-
-  def pluralize(1, object), do: "1 #{object}"
-  def pluralize(count, object), do: "#{count} #{object}s"
 
   def pagination_href(conn, page) do
     conn.request_path <> "?" <> URI.encode_query(Map.put(conn.params, "page", page))

--- a/test/views/shared_view_test.exs
+++ b/test/views/shared_view_test.exs
@@ -3,8 +3,27 @@ defmodule Tilex.SharedViewTest do
 
   import TilexWeb.SharedView
 
-  test "renders rfc 822 dates" do
-    time = %{inserted_at: ~N[2002-10-02 08:00:00.142287]}
-    assert rss_date(time) == "Wed, 02 Oct 2002 08:00:00 GMT"
+  @insert_time %{inserted_at: ~N[2016-11-18 03:34:08.142287]}
+
+  describe "display_date/1" do
+    test "it produces a human-readable date in server's timezone" do
+      assert display_date(@insert_time) == "November 17, 2016"
+    end
+  end
+
+  describe "pluralize/2" do
+    test "counts 1" do
+      assert pluralize(1, "hippo") == "1 hippo"
+    end
+
+    test "counts 2" do
+      assert pluralize(2, "hippo") == "2 hippos"
+    end
+  end
+
+  describe "rss_date/1" do
+    test "renders rfc 822 dates" do
+      assert rss_date(@insert_time) == "Fri, 18 Nov 2016 03:34:08 GMT"
+    end
   end
 end


### PR DESCRIPTION
See #620.

This change refactors a few tests, in the service of adding a `byline` class and `time` tag to our post partial. Those tags help Safari Reader Mode figure out what's important in a post's HTML. See highlighted copy.

![image](https://user-images.githubusercontent.com/2782858/74090404-87998800-4a70-11ea-9f18-1f787defbaf8.png)
