### PR TITLE
Improve stats performance

### DIFF
--- a/lib/mix/tasks/tilex/hdb.ex
+++ b/lib/mix/tasks/tilex/hdb.ex
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.Tilex.Hdb do
   @shortdoc "Replace development PostgreSQL DB with dump from a Heroku app's DB."
 
   @moduledoc """
-  Run `mix tilex.hdb` to copy all data from the production database to the
+  Run `mix tilex.hdb -a tilex` to copy all data from the production database to the
   development database.
   """
 
@@ -43,7 +43,7 @@ defmodule Mix.Tasks.Tilex.Hdb do
   end
 
   defp confirm(prompt) do
-    input = IO.gets("#{prompt} [YyNn] ")
+    input = IO.gets("#{prompt} [y/n] ")
     "y" == input |> String.trim() |> String.downcase()
   end
 

--- a/lib/tilex_web/controllers/stats_controller.ex
+++ b/lib/tilex_web/controllers/stats_controller.ex
@@ -39,8 +39,8 @@ defmodule TilexWeb.StatsController do
 
   defp developer_params(params) do
     %{
-      start_date: date_param(params, "start_date", Timex.to_date({2008, 1, 1})),
-      end_date: date_param(params, "end_date", Timex.today())
+      start_date: date_param(params, "start_date", Date.add(Date.utc_today(), -7)),
+      end_date: date_param(params, "end_date", Date.utc_today())
     }
   end
 

--- a/priv/repo/migrations/20200518184142_add_index_to_request_time_on_requests.exs
+++ b/priv/repo/migrations/20200518184142_add_index_to_request_time_on_requests.exs
@@ -1,0 +1,7 @@
+defmodule Tilex.Repo.Migrations.AddIndexToRequestTimeOnRequests do
+  use Ecto.Migration
+
+  def change do
+    create(index(:requests, :request_time))
+  end
+end

--- a/test/features/developer_views_stats_test.exs
+++ b/test/features/developer_views_stats_test.exs
@@ -1,6 +1,13 @@
 defmodule Features.DeveloperViewsStatsTest do
   use Tilex.IntegrationCase, async: true
 
+  def format_stats_date(%Date{year: year, day: day, month: month}) do
+    day_s = String.pad_leading(Integer.to_string(day), 2, "0")
+    month_s = String.pad_leading(Integer.to_string(month), 2, "0")
+
+    "#{month_s}-#{day_s}-#{year}"
+  end
+
   test "sees total number of posts by channel", %{session: session} do
     developer = Factory.insert!(:developer)
     phoenix_channel = Factory.insert!(:channel, name: "phoenix")
@@ -19,7 +26,10 @@ defmodule Features.DeveloperViewsStatsTest do
     Enum.each(["i'm not fine", "where are all the people", "okay."], fn title ->
       Factory.insert!(
         :post,
-        inserted_at: Timex.to_datetime({2010, 1, 1}),
+        inserted_at:
+          DateTime.utc_now()
+          |> DateTime.add(-:timer.hours(48), :millisecond)
+          |> DateTime.truncate(:second),
         title: title,
         channel: other_channel
       )
@@ -41,8 +51,12 @@ defmodule Features.DeveloperViewsStatsTest do
     assert text_without_newlines(phoenix_channel) =~ "#phoenix 1 post"
 
     session
-    |> fill_in(Query.css("#start-date"), with: "01-01-2009")
-    |> fill_in(Query.css("#end-date"), with: "01-01-2011")
+    |> fill_in(Query.css("#start-date"),
+      with: Date.utc_today() |> Date.add(-7) |> format_stats_date()
+    )
+    |> fill_in(Query.css("#end-date"),
+      with: Date.utc_today() |> Date.add(-1) |> format_stats_date()
+    )
     |> click(Query.css("#filter-submit"))
 
     assert(


### PR DESCRIPTION
Putting an index on the requests table brings the query time down to ~ 200ms in our local database with production data.  Down from 2.5 seconds for 2.5M rows.

