### PR TITLE
User sees Slack emojis past 100 likes

### DIFF
--- a/lib/tilex/notifications/notifiers/slack.ex
+++ b/lib/tilex/notifications/notifiers/slack.ex
@@ -10,6 +10,16 @@ defmodule Tilex.Notifications.Notifiers.Slack do
     :mortar_board:
     :trophy:
     :100:
+    :fire:
+    :zap:
+    :rocket:
+    :saxophone:
+    :mega:
+    :crystal_ball:
+    :beers:
+    :revolving_hearts:
+    :heart_eyes_cat:
+    :scream_cat:
   )
 
   use Tilex.Notifications.Notifier


### PR DESCRIPTION
We are approaching 100 likes on a TIL. We only added Slack emojis up to
100 likes; after that, who knows what will happen?

In the meantime, please STOP liking this post:

https://til.hashrocket.com/posts/2034bed53c-create-new-file-in-vims-file-explorer

This PR solves this very important issue by adding a new realm of Emojis to
achieve, up to 200 likes.