### PR TITLE
Site nav enhancements

### DIFF
--- a/assets/css/_layout.scss
+++ b/assets/css/_layout.scss
@@ -177,6 +177,7 @@ header.site_head {
         }
 
         .site_nav__toggle {
+          display: block;
           width: auto;
           opacity: 1;
           box-shadow: 0 0 3rem transparentize($navy, 0.8);
@@ -211,6 +212,7 @@ header.site_head {
   left: 100%;
   bottom: 0;
   width: 0;
+  display: none;
   overflow: hidden;
   transition: opacity 0.2s;
   opacity: 0;

--- a/lib/tilex_web/templates/layout/app.html.eex
+++ b/lib/tilex_web/templates/layout/app.html.eex
@@ -62,6 +62,8 @@
       </nav>
     <% end %>
 
+    <%= render "site_nav.html", conn: @conn %>
+
     <header class="site_head <%= if System.get_env("BANNER"), do: "has-banner" %>">
       <%= if (System.get_env("BANNER")) do %>
         <div class="banner">
@@ -92,8 +94,6 @@
     <main>
       <%= render @view_module, @view_template, assigns %>
     </main>
-
-    <%= render "site_nav.html", conn: @conn %>
 
     <script>
       window.Tilex = window.Tilex || {};


### PR DESCRIPTION
This makes tabbing through the site a little easier. Currently when you visit the home page you have to tab through each til, any links in it, all the buttons, etc. Now when you visit the site and tab navigate, you should tab right through the navigation first. 

There was also an issue with the search, currently it was just width 0, which allowed you tab into it, but you couldn't see what you were doing. Now you can choose to open it (return), or keep tabbing to the next nav item. 

Fixes #641