### PR TITLE
Replace custom meta tag with Phoenix html csrf_meta_tag

### DIFF
--- a/assets/js/like.js
+++ b/assets/js/like.js
@@ -1,7 +1,7 @@
 $(function(){
 
 
-  var csrf = document.querySelector("meta[name=csrf]").content;
+  var csrf = document.querySelector('meta[name=csrf-token]').content;
 
   function LikeButton(el) {
     this.id = el.id;

--- a/lib/tilex_web/templates/layout/app.html.eex
+++ b/lib/tilex_web/templates/layout/app.html.eex
@@ -13,8 +13,8 @@
     <meta itemprop="brand" content="Today I Learned">
     <meta itemprop="description" content="<%= description %>">
 
+    <%= csrf_meta_tag() %>
     <meta name="author" content="<%= Application.get_env(:tilex, :organization_name)%>">
-    <meta name="csrf" content="<%= Plug.CSRFProtection.get_csrf_token() %>">
     <meta name="description" content="<%= description %>">
     <meta name="format-detection" content="telephone=no">
     <meta name="image" property="og:image" content="<%= image %>">


### PR DESCRIPTION
TIL while playing with liveview that [Phoenix.HTML.Tag.csrf_meta_tag/0](https://github.com/phoenixframework/phoenix_html/blob/v2.14.2/lib/phoenix_html/tag.ex#L259)  exists? Rather than maintain our own logic, it may be better to just let Phoenix handle it? 