### PR TITLE
Site Nav UX

### DIFF
--- a/assets/js/tilex.js
+++ b/assets/js/tilex.js
@@ -20,6 +20,15 @@ $(function() {
     '.site_nav__link',
     function(e) {
       e.preventDefault();
+
+      // Close all OTHER links to prevent overlap
+      const site_nav_links = document.getElementsByClassName('site_nav__link')
+      for (let i = 0; i < site_nav_links.length; i++) {
+        if ($(this).parent()[0] != $(site_nav_links[i]).parent()[0]) {
+          $(site_nav_links[i]).closest('li').removeClass('site_nav--open')
+        }
+      }
+
       $(this)
         .closest('li')
         .toggleClass('site_nav--open')


### PR DESCRIPTION
Small UX improvement to prevent overlap of site nav links when clicking through. This can be seen when clicking from the about link to the search link - the search input opens behind the "about" pop up.