### PR TITLE
Fix broken markdown when code snippet has `>` operators

### DIFF
--- a/lib/tilex/markdown.ex
+++ b/lib/tilex/markdown.ex
@@ -4,13 +4,12 @@ defmodule Tilex.Markdown do
   def to_html_live(markdown) do
     earmark_options = %Earmark.Options{
       code_class_prefix: "language-",
-      pure_links: true,
-      smartypants: false
+      pure_links: true
     }
 
     markdown
-    |> HtmlSanitizeEx.markdown_html()
     |> Earmark.as_html!(earmark_options)
+    |> HtmlSanitizeEx.markdown_html()
     |> expand_relative_links()
     |> String.trim()
   end

--- a/test/lib/tilex/markdown_test.exs
+++ b/test/lib/tilex/markdown_test.exs
@@ -25,8 +25,13 @@ defmodule Lib.Tilex.MarkdownTest do
       expected: "<pre><code class=\"elixir language-elixir\">defmodule Foo do\nend</code></pre>"
     },
     %{
+      input: "```elixir\niex> IO.inspect(\"Hello World!\")\n```",
+      expected:
+        "<pre><code class=\"elixir language-elixir\">iex&gt; IO.inspect(&quot;Hello World!&quot;)</code></pre>"
+    },
+    %{
       input: "<script>alert('A great grasshopper!')</script>",
-      expected: "<p>alert(&#39;A great grasshopper!&#39;)</p>"
+      expected: "<p>alert(‘A great grasshopper!’)</p>"
     },
     %{
       input: "Some http://link.com?foo=bar",
@@ -47,11 +52,11 @@ defmodule Lib.Tilex.MarkdownTest do
     },
     %{
       input: "Here's [my-link]\n\n[my-link]: http://foo/bar",
-      expected: "<p>Here&#39;s <a href=\"http://foo/bar\" title=\"\">my-link</a></p>"
+      expected: "<p>Here’s <a href=\"http://foo/bar\" title=\"\">my-link</a></p>"
     },
     %{
       input: "Here's [my-link]\n\n[my-link]: http://foo/bar \"With Title\"",
-      expected: "<p>Here&#39;s <a href=\"http://foo/bar\" title=\"With Title\">my-link</a></p>"
+      expected: "<p>Here’s <a href=\"http://foo/bar\" title=\"With Title\">my-link</a></p>"
     },
     %{
       input: "some <a href=\"http://link.com?foo=bar\">Link</a>",


### PR DESCRIPTION
- [x] Fix broken markdown when code snippet has `>` operators