### PR TITLE
feat: add a til posts api endpoint

### DIFF
--- a/lib/tilex/pageable.ex
+++ b/lib/tilex/pageable.ex
@@ -1,0 +1,16 @@
+defmodule Tilex.Pageable do
+  defmacro __using__(_params) do
+    quote do
+      import Tilex.Pageable
+    end
+  end
+
+  def robust_page(%{"page" => page}) do
+    case Integer.parse(page) do
+      :error -> 1
+      {integer, _remainder} -> integer
+    end
+  end
+
+  def robust_page(_params), do: 1
+end

--- a/lib/tilex/posts.ex
+++ b/lib/tilex/posts.ex
@@ -93,16 +93,10 @@ defmodule Tilex.Posts do
       |> Repo.preload(:developer)
       |> Repo.preload(:channel)
 
-    offset = (page - 1) * Application.get_env(:tilex, :page_size)
-    limit = Application.get_env(:tilex, :page_size) + 1
-
-    {Enum.slice(posts, offset..(offset + limit)), Enum.count(posts)}
+    {Enum.slice(posts, offset(page)..(offset(page) + limit)), Enum.count(posts)}
   end
 
   defp posts(page) do
-    offset = (page - 1) * Application.get_env(:tilex, :page_size)
-    limit = Application.get_env(:tilex, :page_size) + 1
-
     from(
       p in Post,
       order_by: [desc: p.inserted_at],
@@ -110,7 +104,16 @@ defmodule Tilex.Posts do
       join: d in assoc(p, :developer),
       preload: [channel: c, developer: d],
       limit: ^limit,
-      offset: ^offset
+      offset: ^offset(page)
     )
+  end
+
+  defp offset(page) do
+    page = (page > 1 && page) || 1
+    (page - 1) * Application.get_env(:tilex, :page_size)
+  end
+
+  defp limit do
+    Application.get_env(:tilex, :page_size) + 1
   end
 end

--- a/lib/tilex/posts.ex
+++ b/lib/tilex/posts.ex
@@ -30,6 +30,17 @@ defmodule Tilex.Posts do
     {Repo.all(query), posts_count, channel}
   end
 
+  def by_count(limit: limit) do
+    query =
+      from(
+        p in Post,
+        order_by: [desc: p.inserted_at],
+        limit: ^limit
+      )
+
+    Repo.all(query)
+  end
+
   def by_developer(username, limit: limit) do
     query =
       from(

--- a/lib/tilex/posts.ex
+++ b/lib/tilex/posts.ex
@@ -30,23 +30,6 @@ defmodule Tilex.Posts do
     {Repo.all(query), posts_count, channel}
   end
 
-  def by_count(limit: limit) do
-    query =
-      from(
-        p in Post,
-        join: c in assoc(p, :channel),
-        join: d in assoc(p, :developer),
-        order_by: [desc: p.inserted_at],
-        limit: ^limit
-      )
-
-    posts = Repo.all(query)
-
-    posts
-    |> Repo.preload(:channel)
-    |> Repo.preload(:developer)
-  end
-
   def by_developer(username, limit: limit) do
     query =
       from(

--- a/lib/tilex/posts.ex
+++ b/lib/tilex/posts.ex
@@ -34,11 +34,17 @@ defmodule Tilex.Posts do
     query =
       from(
         p in Post,
+        join: c in assoc(p, :channel),
+        join: d in assoc(p, :developer),
         order_by: [desc: p.inserted_at],
         limit: ^limit
       )
 
-    Repo.all(query)
+    posts = Repo.all(query)
+
+    posts
+    |> Repo.preload(:channel)
+    |> Repo.preload(:developer)
   end
 
   def by_developer(username, limit: limit) do

--- a/lib/tilex_web/controllers/api/post_controller.ex
+++ b/lib/tilex_web/controllers/api/post_controller.ex
@@ -1,0 +1,17 @@
+defmodule TilexWeb.Api.PostController do
+  @moduledoc "
+  This module implements a public API for querying the Tilex feed
+  "
+
+  use TilexWeb, :controller
+  alias Tilex.{Posts}
+
+  @doc """
+  This functions allows external requesters to retrieve the feed of til in json format
+  """
+  def index(conn, params) do
+    posts = Posts.by_count(limit: params["limit"] || 10)
+
+    render(conn, "index.json", posts: posts)
+  end
+end

--- a/lib/tilex_web/controllers/api/post_controller.ex
+++ b/lib/tilex_web/controllers/api/post_controller.ex
@@ -4,13 +4,15 @@ defmodule TilexWeb.Api.PostController do
   "
 
   use TilexWeb, :controller
+  use Tilex.Pageable
   alias Tilex.{Posts}
 
   @doc """
   This functions allows external requesters to retrieve the feed of til in json format
   """
   def index(conn, params) do
-    posts = Posts.by_count(limit: params["limit"] || 10)
+    page = robust_page(params)
+    posts = Posts.all(page)
 
     render(conn, "index.json", posts: posts)
   end

--- a/lib/tilex_web/controllers/post_controller.ex
+++ b/lib/tilex_web/controllers/post_controller.ex
@@ -1,5 +1,6 @@
 defmodule TilexWeb.PostController do
   use TilexWeb, :controller
+  use Tilex.Pageable
   import Ecto.Query
 
   alias Guardian.Plug
@@ -219,15 +220,6 @@ defmodule TilexWeb.PostController do
     conn
     |> assign(:canonical_url, canonical_post)
   end
-
-  defp robust_page(%{"page" => page}) do
-    case Integer.parse(page) do
-      :error -> 1
-      {integer, _remainder} -> integer
-    end
-  end
-
-  defp robust_page(_params), do: 1
 
   defp post_params(params) do
     Map.take(params, ["body", "channel_id", "title"])

--- a/lib/tilex_web/router.ex
+++ b/lib/tilex_web/router.ex
@@ -41,6 +41,7 @@ defmodule TilexWeb.Router do
     pipe_through([:api])
 
     get("/developer_posts.json", Api.DeveloperPostController, :index)
+    get("/posts.json", Api.PostController, :index, as: :api_post)
   end
 
   get("/rss", TilexWeb.FeedController, :index)

--- a/lib/tilex_web/router.ex
+++ b/lib/tilex_web/router.ex
@@ -41,7 +41,7 @@ defmodule TilexWeb.Router do
     pipe_through([:api])
 
     get("/developer_posts.json", Api.DeveloperPostController, :index)
-    get("/posts.json", Api.PostController, :index, as: :api_post)
+    get("/recent_posts.json", Api.PostController, :index, as: :api_post)
   end
 
   get("/rss", TilexWeb.FeedController, :index)

--- a/lib/tilex_web/views/api/developer_post_view.ex
+++ b/lib/tilex_web/views/api/developer_post_view.ex
@@ -4,7 +4,7 @@ defmodule TilexWeb.Api.DeveloperPostView do
   def render("index.json", %{posts: posts}) do
     %{
       data: %{
-        posts: render_many(posts, Tilex.Api.PostView, "post.json")
+        posts: render_many(posts, TilexWeb.Api.PostView, "post.json")
       }
     }
   end

--- a/lib/tilex_web/views/api/post_view.ex
+++ b/lib/tilex_web/views/api/post_view.ex
@@ -4,8 +4,17 @@ defmodule TilexWeb.Api.PostView do
   def render("index.json", %{posts: posts}) do
     %{
       data: %{
-        posts: render_many(posts, TilexWeb.Api.PostView, "post.json")
+        posts: render_many(posts, TilexWeb.Api.PostView, "post_with_developer.json")
       }
+    }
+  end
+
+  def render("post_with_developer.json", %{post: post}) do
+    %{
+      slug: post.slug,
+      title: post.title,
+      developer_username: post.developer.username,
+      channel_name: post.channel.name
     }
   end
 

--- a/lib/tilex_web/views/api/post_view.ex
+++ b/lib/tilex_web/views/api/post_view.ex
@@ -1,5 +1,13 @@
-defmodule Tilex.Api.PostView do
+defmodule TilexWeb.Api.PostView do
   use TilexWeb, :view
+
+  def render("index.json", %{posts: posts}) do
+    %{
+      data: %{
+        posts: render_many(posts, TilexWeb.Api.PostView, "post.json")
+      }
+    }
+  end
 
   def render("post.json", %{post: post}), do: Map.take(post, [:slug, :title])
 end

--- a/test/controllers/api/post_controller_test.exs
+++ b/test/controllers/api/post_controller_test.exs
@@ -1,0 +1,91 @@
+defmodule Tilex.Api.PostControllerTest do
+  use TilexWeb.ConnCase, async: true
+
+  alias Tilex.Factory
+
+  test "returns the 10 most recent posts", %{conn: conn} do
+      Factory.insert!(:post,
+        title: "__shouldn't be there__",
+        developer: Factory.insert!(:developer, username: "ricksanchez"),
+        inserted_at: Timex.to_datetime({{2018, 1, 1}, {1, 1, 0}}, "Etc/UTC")
+      )
+
+    lizlemon = Factory.insert!(:developer, username: "lizlemon")
+    Factory.insert!(:post, title: "Eye-rolling Is My Life", developer: lizlemon,
+      inserted_at: Timex.to_datetime({{2018, 1, 2}, {1, 1, 0}}, "Etc/UTC")
+    )
+
+    jackdonaughy = Factory.insert!(:developer, username: "jackdonaughy")
+    jack_post_titles = [
+      "30 Rock Is Awesome",
+      "I'm a Big Meanie",
+      "Get It Together, Lemon",
+      "Rick & Morty Portal Gun Instructions",
+      "Plumbus Essentials",
+      "Setting Up Interdimensional Cable",
+      "Wanna Build My App?",
+      "What Is My Purpose?",
+      "Rick C137 Log Files",
+    ]
+
+    jack_post_titles
+    |> Enum.with_index()
+    |> Enum.map(fn {title, index} ->
+      Factory.insert!(:post,
+        title: title,
+        developer: jackdonaughy,
+        inserted_at: Timex.to_datetime({{2018, 1, 2}, {1, 1, index}}, "Etc/UTC")
+      )
+    end)
+
+    conn = get(conn, api_post_path(conn, :index))
+
+    expected_post_titles = ["Eye-rolling Is My Life"] ++ jack_post_titles
+    json_response(conn, 200)["data"]["posts"]
+    |> Enum.reverse()
+    |> Enum.map(fn post -> post["title"] end)
+    |> (fn posts ->
+          assert length(posts) === 10
+          assert posts == expected_post_titles
+        end).()
+  end
+
+  test "returns the number of posts set by the limit param when present", %{conn: conn} do
+    jackdonaughy = Factory.insert!(:developer, username: "jackdonaughy")
+    jack_post_titles = [
+      "30 Rock Is Awesome",
+      "I'm a Big Meanie",
+      "Get It Together, Lemon",
+      "Rick & Morty Portal Gun Instructions",
+      "Plumbus Essentials",
+      "Setting Up Interdimensional Cable",
+      "Wanna Build My App?",
+      "What Is My Purpose?",
+      "Rick C137 Log Files",
+      "Red",
+      "Green",
+      "Black",
+      "Blue",
+      "White",
+      "Silver",
+      "Gold"
+    ]
+
+    jack_post_titles
+    |> Enum.with_index()
+    |> Enum.map(fn {title, index} ->
+      Factory.insert!(:post,
+        title: title,
+        developer: jackdonaughy,
+        inserted_at: Timex.to_datetime({{2018, 1, 2}, {1, 1, index}}, "Etc/UTC")
+      )
+    end)
+
+    conn = get(conn, api_post_path(conn, :index, limit: 16))
+
+    json_response(conn, 200)["data"]["posts"]
+    |> (fn posts ->
+      assert length(posts) == 16
+    end).()
+  end
+end

--- a/test/controllers/api/post_controller_test.exs
+++ b/test/controllers/api/post_controller_test.exs
@@ -3,33 +3,19 @@ defmodule Tilex.Api.PostControllerTest do
 
   alias Tilex.Factory
 
-  test "returns the 10 most recent posts", %{conn: conn} do
-    Factory.insert!(:post,
-      title: "__shouldn't be there__",
-      developer: Factory.insert!(:developer, username: "ricksanchez"),
-      inserted_at: Timex.to_datetime({{2018, 1, 1}, {1, 1, 0}}, "Etc/UTC")
-    )
-
+  test "returns the entries", %{conn: conn} do
     lizlemon = Factory.insert!(:developer, username: "lizlemon")
-
     Factory.insert!(:post,
       title: "Eye-rolling Is My Life",
       developer: lizlemon,
-      inserted_at: Timex.to_datetime({{2018, 1, 2}, {1, 1, 0}}, "Etc/UTC")
+      inserted_at: Timex.to_datetime({{2018, 1, 1}, {1, 1, 0}}, "Etc/UTC")
     )
 
     jackdonaughy = Factory.insert!(:developer, username: "jackdonaughy")
-
     jack_post_titles = [
       "30 Rock Is Awesome",
       "I'm a Big Meanie",
       "Get It Together, Lemon",
-      "Rick & Morty Portal Gun Instructions",
-      "Plumbus Essentials",
-      "Setting Up Interdimensional Cable",
-      "Wanna Build My App?",
-      "What Is My Purpose?",
-      "Rick C137 Log Files"
     ]
 
     jack_post_titles
@@ -38,7 +24,7 @@ defmodule Tilex.Api.PostControllerTest do
       Factory.insert!(:post,
         title: title,
         developer: jackdonaughy,
-        inserted_at: Timex.to_datetime({{2018, 1, 2}, {1, 1, index}}, "Etc/UTC")
+        inserted_at: Timex.to_datetime({{2018, 1, 1}, {1, 2, index}}, "Etc/UTC")
       )
     end)
 
@@ -50,48 +36,8 @@ defmodule Tilex.Api.PostControllerTest do
     |> Enum.reverse()
     |> Enum.map(fn post -> post["title"] end)
     |> (fn posts ->
-          assert length(posts) === 10
+          assert length(posts) === 4
           assert posts == expected_post_titles
-        end).()
-  end
-
-  test "returns the number of posts set by the limit param when present", %{conn: conn} do
-    jackdonaughy = Factory.insert!(:developer, username: "jackdonaughy")
-
-    jack_post_titles = [
-      "30 Rock Is Awesome",
-      "I'm a Big Meanie",
-      "Get It Together, Lemon",
-      "Rick & Morty Portal Gun Instructions",
-      "Plumbus Essentials",
-      "Setting Up Interdimensional Cable",
-      "Wanna Build My App?",
-      "What Is My Purpose?",
-      "Rick C137 Log Files",
-      "Red",
-      "Green",
-      "Black",
-      "Blue",
-      "White",
-      "Silver",
-      "Gold"
-    ]
-
-    jack_post_titles
-    |> Enum.with_index()
-    |> Enum.map(fn {title, index} ->
-      Factory.insert!(:post,
-        title: title,
-        developer: jackdonaughy,
-        inserted_at: Timex.to_datetime({{2018, 1, 2}, {1, 1, index}}, "Etc/UTC")
-      )
-    end)
-
-    conn = get(conn, api_post_path(conn, :index, limit: 16))
-
-    json_response(conn, 200)["data"]["posts"]
-    |> (fn posts ->
-          assert length(posts) == 16
         end).()
   end
 end

--- a/test/controllers/api/post_controller_test.exs
+++ b/test/controllers/api/post_controller_test.exs
@@ -4,18 +4,22 @@ defmodule Tilex.Api.PostControllerTest do
   alias Tilex.Factory
 
   test "returns the 10 most recent posts", %{conn: conn} do
-      Factory.insert!(:post,
-        title: "__shouldn't be there__",
-        developer: Factory.insert!(:developer, username: "ricksanchez"),
-        inserted_at: Timex.to_datetime({{2018, 1, 1}, {1, 1, 0}}, "Etc/UTC")
-      )
+    Factory.insert!(:post,
+      title: "__shouldn't be there__",
+      developer: Factory.insert!(:developer, username: "ricksanchez"),
+      inserted_at: Timex.to_datetime({{2018, 1, 1}, {1, 1, 0}}, "Etc/UTC")
+    )
 
     lizlemon = Factory.insert!(:developer, username: "lizlemon")
-    Factory.insert!(:post, title: "Eye-rolling Is My Life", developer: lizlemon,
+
+    Factory.insert!(:post,
+      title: "Eye-rolling Is My Life",
+      developer: lizlemon,
       inserted_at: Timex.to_datetime({{2018, 1, 2}, {1, 1, 0}}, "Etc/UTC")
     )
 
     jackdonaughy = Factory.insert!(:developer, username: "jackdonaughy")
+
     jack_post_titles = [
       "30 Rock Is Awesome",
       "I'm a Big Meanie",
@@ -25,7 +29,7 @@ defmodule Tilex.Api.PostControllerTest do
       "Setting Up Interdimensional Cable",
       "Wanna Build My App?",
       "What Is My Purpose?",
-      "Rick C137 Log Files",
+      "Rick C137 Log Files"
     ]
 
     jack_post_titles
@@ -41,6 +45,7 @@ defmodule Tilex.Api.PostControllerTest do
     conn = get(conn, api_post_path(conn, :index))
 
     expected_post_titles = ["Eye-rolling Is My Life"] ++ jack_post_titles
+
     json_response(conn, 200)["data"]["posts"]
     |> Enum.reverse()
     |> Enum.map(fn post -> post["title"] end)
@@ -52,6 +57,7 @@ defmodule Tilex.Api.PostControllerTest do
 
   test "returns the number of posts set by the limit param when present", %{conn: conn} do
     jackdonaughy = Factory.insert!(:developer, username: "jackdonaughy")
+
     jack_post_titles = [
       "30 Rock Is Awesome",
       "I'm a Big Meanie",
@@ -85,7 +91,7 @@ defmodule Tilex.Api.PostControllerTest do
 
     json_response(conn, 200)["data"]["posts"]
     |> (fn posts ->
-      assert length(posts) == 16
-    end).()
+          assert length(posts) == 16
+        end).()
   end
 end

--- a/test/controllers/api/post_controller_test.exs
+++ b/test/controllers/api/post_controller_test.exs
@@ -5,6 +5,7 @@ defmodule Tilex.Api.PostControllerTest do
 
   test "returns the entries", %{conn: conn} do
     lizlemon = Factory.insert!(:developer, username: "lizlemon")
+
     Factory.insert!(:post,
       title: "Eye-rolling Is My Life",
       developer: lizlemon,

--- a/test/controllers/api/post_controller_test.exs
+++ b/test/controllers/api/post_controller_test.exs
@@ -12,10 +12,11 @@ defmodule Tilex.Api.PostControllerTest do
     )
 
     jackdonaughy = Factory.insert!(:developer, username: "jackdonaughy")
+
     jack_post_titles = [
       "30 Rock Is Awesome",
       "I'm a Big Meanie",
-      "Get It Together, Lemon",
+      "Get It Together, Lemon"
     ]
 
     jack_post_titles


### PR DESCRIPTION
Adds the endpoint `/api/recent_posts.json` to fetch the json feed of TIL
* Supports an optional `limit` param for adjusting the number returned - default is 10
