### PR TITLE
Fix slack notification if post includes double quote

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -33,6 +33,7 @@ config :tilex, :hosted_domain, System.get_env("HOSTED_DOMAIN")
 config :tilex, :guest_author_allowlist, System.get_env("GUEST_AUTHOR_ALLOWLIST")
 config :tilex, :date_display_tz, System.get_env("DATE_DISPLAY_TZ")
 config :tilex, :imgur_client_id, System.get_env("IMGUR_CLIENT_ID")
+config :tilex, :slack_endpoint, "https://hooks.slack.com#{System.get_env("slack_post_endpoint")}"
 
 config :tilex,
        :rate_limiter_requests_per_time_period,

--- a/config/test.exs
+++ b/config/test.exs
@@ -31,6 +31,7 @@ config :tilex, :slack_notifier, Test.Notifications.Notifiers.Slack
 config :tilex, :twitter_notifier, Test.Notifications.Notifiers.Twitter
 config :tilex, :date_time_module, Tilex.DateTimeMock
 config :tilex, :date_display_tz, "America/Chicago"
+config :tilex, :slack_endpoint, "https://slack.test.com/abc/123"
 
 config :tilex, :async_feature_test, System.get_env("ASYNC_FEATURE_TEST") == "yes"
 

--- a/lib/test/notifications/notifiers/slack.ex
+++ b/lib/test/notifications/notifiers/slack.ex
@@ -9,7 +9,7 @@ defmodule Test.Notifications.Notifiers.Slack do
     :ok
   end
 
-  def handle_page_views_report(_pid) do
+  def handle_page_views_report(_report) do
     :ok
   end
 end

--- a/lib/test/notifications/notifiers/twitter.ex
+++ b/lib/test/notifications/notifiers/twitter.ex
@@ -9,7 +9,7 @@ defmodule Test.Notifications.Notifiers.Twitter do
     :ok
   end
 
-  def handle_page_views_report(_pid) do
+  def handle_page_views_report(_report) do
     :ok
   end
 end

--- a/lib/tilex/notifications/notifications.ex
+++ b/lib/tilex/notifications/notifications.ex
@@ -78,9 +78,9 @@ defmodule Tilex.Notifications do
     {:noreply, :nostate}
   end
 
-  def handle_call({:page_views_report, string_pid}, from, :nostate) do
+  def handle_call({:page_views_report, report}, from, :nostate) do
     notifiers()
-    |> Enum.each(& &1.page_views_report(string_pid))
+    |> Enum.each(& &1.page_views_report(report))
 
     {:reply, from, true}
   end

--- a/lib/tilex/notifications/notifiers/notifier.ex
+++ b/lib/tilex/notifications/notifiers/notifier.ex
@@ -27,7 +27,7 @@ defmodule Tilex.Notifications.Notifier do
 
   @callback handle_post_created(Post.t(), Developer.t(), Channel.t(), url :: String.t()) :: any
   @callback handle_post_liked(Post.t(), Developer.t(), url :: String.t()) :: any
-  @callback handle_page_views_report(pid) :: any
+  @callback handle_page_views_report(String.t()) :: any
 
   defmacro __using__(_) do
     quote location: :keep do

--- a/lib/tilex/notifications/notifiers/twitter.ex
+++ b/lib/tilex/notifications/notifiers/twitter.ex
@@ -12,7 +12,7 @@ defmodule Tilex.Notifications.Notifiers.Twitter do
     :ok
   end
 
-  def handle_page_views_report(_pid) do
+  def handle_page_views_report(_report) do
     :ok
   end
 

--- a/lib/tilex/posts.ex
+++ b/lib/tilex/posts.ex
@@ -93,7 +93,7 @@ defmodule Tilex.Posts do
       |> Repo.preload(:developer)
       |> Repo.preload(:channel)
 
-    {Enum.slice(posts, offset(page)..(offset(page) + limit)), Enum.count(posts)}
+    {Enum.slice(posts, offset(page)..(offset(page) + limit())), Enum.count(posts)}
   end
 
   defp posts(page) do
@@ -103,7 +103,7 @@ defmodule Tilex.Posts do
       join: c in assoc(p, :channel),
       join: d in assoc(p, :developer),
       preload: [channel: c, developer: d],
-      limit: ^limit,
+      limit: ^limit(),
       offset: ^offset(page)
     )
   end

--- a/test/tilex/notifications/notifiers/slack_test.exs
+++ b/test/tilex/notifications/notifiers/slack_test.exs
@@ -1,0 +1,85 @@
+defmodule Tilex.Notifications.Notifiers.SlackTest do
+  use ExUnit.Case, async: true
+
+  alias Tilex.Notifications.Notifiers.Slack
+  alias Tilex.Channel
+  alias Tilex.Developer
+  alias Tilex.Post
+
+  defmodule HTTPMock do
+    def request(
+          :post,
+          {'https://slack.test.com/abc/123', [], 'application/json', payload},
+          [],
+          []
+        ) do
+      {:ok, payload}
+    end
+  end
+
+  describe "handle_post_created/5" do
+    test "notifies post creation for simple post" do
+      post = %Post{title: "simple post"}
+      developer = %Developer{username: "vnegrisolo"}
+      channel = %Channel{name: "ruby"}
+      url = "http://til.test.com/abc123"
+      message = "vnegrisolo created a new post <http://til.test.com/abc123|simple post> in #ruby"
+
+      assert Slack.handle_post_created(post, developer, channel, url, HTTPMock) ==
+               {:ok, "{\"text\": \"#{message}\"}"}
+    end
+
+    test "notifies post creation for post with double quotes" do
+      post = %Post{title: "post with \"double\" quote"}
+      developer = %Developer{username: "vnegrisolo"}
+      channel = %Channel{name: "ruby"}
+      url = "http://til.test.com/abc123"
+
+      message =
+        "vnegrisolo created a new post <http://til.test.com/abc123|post with 'double' quote> in #ruby"
+
+      assert Slack.handle_post_created(post, developer, channel, url, HTTPMock) ==
+               {:ok, "{\"text\": \"#{message}\"}"}
+    end
+  end
+
+  describe "handle_post_liked/4" do
+    test "notifies post liked for simple post" do
+      post = %Post{title: "simple post", max_likes: 20}
+      developer = %Developer{username: "vnegrisolo"}
+      url = "http://til.test.com/abc123"
+
+      message =
+        "vnegrisolo's post has 20 likes! :birthday: - <http://til.test.com/abc123|simple post>"
+
+      assert Slack.handle_post_liked(post, developer, url, HTTPMock) ==
+               {:ok, "{\"text\": \"#{message}\"}"}
+    end
+
+    test "notifies post liked for post with double quotes" do
+      post = %Post{title: "post with \"double\" quote", max_likes: 20}
+      developer = %Developer{username: "vnegrisolo"}
+      url = "http://til.test.com/abc123"
+
+      message =
+        "vnegrisolo's post has 20 likes! :birthday: - <http://til.test.com/abc123|post with 'double' quote>"
+
+      assert Slack.handle_post_liked(post, developer, url, HTTPMock) ==
+               {:ok, "{\"text\": \"#{message}\"}"}
+    end
+  end
+
+  describe "handle_page_views_report/2" do
+    test "notifies page views report" do
+      report = """
+      Best Day Last Week:   10
+      Last Week:            20
+      Best Day Week Before: 30
+      Week Before:          40
+      """
+
+      assert Slack.handle_page_views_report(report, HTTPMock) ==
+               {:ok, "{\"text\": \"#{report}\"}"}
+    end
+  end
+end


### PR DESCRIPTION
- [x] Fix slack notification if post includes double quote