### PR TITLE
Fix RSS Autodiscovery

### DIFF
--- a/lib/tilex_web/templates/layout/app.html.eex
+++ b/lib/tilex_web/templates/layout/app.html.eex
@@ -33,7 +33,7 @@
     <meta name="twitter:title" content="<%= twitter_title(assigns[:post]) %>">
 
     <link href='//fonts.googleapis.com/css?family=Raleway:700,900&display=swap' rel='stylesheet' type='text/css'>
-    <link rel="alternate feed" type="application/rss+xml" title="Today I Learned" href="<%= feed_path(@conn, :index) %>">
+    <link rel="alternate" type="application/rss+xml" title="Today I Learned" href="<%= feed_path(@conn, :index) %>">
 
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/atom-one-dark.min.css">
 


### PR DESCRIPTION
When trying to add your feed to my rss reader I got the following error:

![Screenshot 2021-10-27 at 12 54 32](https://user-images.githubusercontent.com/379915/139053141-fa874a33-54d3-4457-8f19-891aed8022ae.png)

I had a look and `<link rel="alternate feed" ...>` seems to be the problem.

According to [the RSS spec](https://www.rssboard.org/rss-autodiscovery#element-link-rel):

> The rel attribute MUST have a value of "alternate", a keyword that indicates the link is an alternate version of the site's main content.
>
> Although for purposes other than autodiscovery this attribute MAY contain multiple keywords separated by spaces, __in an autodiscovery link, the value MUST NOT contain keywords other than "alternate"__.
>
> Additionally, though rel keywords are case-insensitive elsewhere, "alternate" MUST be lowercase.