### PR TITLE
Add statistics link when signed in

### DIFF
--- a/assets/css/_layout.scss
+++ b/assets/css/_layout.scss
@@ -230,6 +230,12 @@ header.site_head {
   }
 }
 
+.site_nav__admin_statistics {
+  a.site_nav__link {
+    background-image: svg-url(stats, $red);
+  }
+}
+
 .site_nav__about {
   position: relative;
 

--- a/lib/tilex_web/templates/layout/site_nav.html.eex
+++ b/lib/tilex_web/templates/layout/site_nav.html.eex
@@ -33,11 +33,7 @@
       </div>
     </li>
     <li class="site_nav__statistics">
-      <%= if current_user(@conn) do %>
-        <%= link("Statistics", to: stats_path(@conn, :developer), class: "site_nav__link") %>
-      <% else %>
-        <%= link("Statistics", to: stats_path(@conn, :index), class: "site_nav__link") %>
-      <% end %>
+      <%= link("Statistics", to: stats_path(@conn, :index), class: "site_nav__link") %>
     </li>
     <li class="site_nav__newsletter">
       <%= link("Newsletter", to: "https://www.getrevue.co/profile/til/", class: "site_nav__link") %>
@@ -45,5 +41,10 @@
     <li class="site_nav__surprise_me">
       <%= link("Surprise Me", to: post_path(@conn, :random), class: "site_nav__link", rel: "nofollow") %>
     </li>
+    <%= if current_user(@conn) do %>
+    <li class="site_nav__admin_statistics">
+        <%= link("Statistics", to: stats_path(@conn, :developer), class: "site_nav__link") %>
+    </li>
+    <% end %>
   </ul>
 </nav>


### PR DESCRIPTION
This would keep the current statistics link in place, and move the admin statistics link to the bottom of the nav if signed in.

<img width="1029" alt="Screen Shot 2021-12-26 at 13 20 12" src="https://user-images.githubusercontent.com/1136388/147416885-eb61b134-8df8-4844-9971-0cd4bc165c8a.png">
