### PR TITLE
fix(appsignal-95): add index for request time in chicago

### DIFF
--- a/priv/repo/migrations/20220425135720_add_request_time_in_chicago_tz_index_to_requests.exs
+++ b/priv/repo/migrations/20220425135720_add_request_time_in_chicago_tz_index_to_requests.exs
@@ -1,0 +1,18 @@
+defmodule Tilex.Repo.Migrations.AddRequestTimeInChicagoTzIndexToRequests do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    execute """
+      create index concurrently index_requests_on_request_time_in_chicago on requests (timezone('america/chicago', request_time))
+    """
+  end
+
+  def down do
+    execute """
+      drop index concurrently index_requests_on_request_time_in_chicago
+    """
+  end
+end

--- a/priv/repo/migrations/20220429184256_add_request_time_in_application_timezone_index_to_requests.exs
+++ b/priv/repo/migrations/20220429184256_add_request_time_in_application_timezone_index_to_requests.exs
@@ -1,0 +1,28 @@
+defmodule Tilex.Repo.Migrations.AddRequestTimeInApplicationTimezoneIndexToRequests do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    application_timezone = Application.get_env(:tilex, :date_display_tz, "america/chicago")
+                           |> String.downcase()
+    execute """
+      drop index concurrently if exists index_requests_on_request_time_in_chicago
+    """
+
+    execute """
+      create index concurrently if not exists index_requests_on_request_time_in_app_tz on requests (timezone('#{application_timezone}', request_time))
+    """
+  end
+
+  def down do
+    execute """
+      drop index concurrently if exists index_requests_on_request_time_in_app_tz
+    """
+
+    execute """
+      create index concurrently if not exists index_requests_on_request_time_in_chicago on requests (timezone('america/chicago', request_time))
+    """
+  end
+end


### PR DESCRIPTION
Fixes a timeout on the report query that bubbled up to a `MatchError` in signal. 

This adds a [functional index](https://www.postgresql.org/docs/current/indexes-expressional.html) to `requests.request_time`, which was ultimately used by the left hand side of the [where clause in the report query](https://github.com/hashrocket/tilex/blob/6fe95bba7ddddef7dd138dab654f4052d4e060a5/lib/tilex/page_views_report.ex#L4). 

## Benchmark

Before adding the index, we are seeing the following performance for the [report query](https://github.com/hashrocket/tilex/blob/6fe95bba7ddddef7dd138dab654f4052d4e060a5/lib/tilex/page_views_report.ex#L3): 
* **Prod** - `> 30s`
* **Development (with the same database - > 5 million records in the table)** - `~ 10s`. 

After adding the index in this PR, we're seeing the query run in `98ms` locally

[Incident #95](https://appsignal.com/5bb25369-c1b5-4dbb-afb3-7a42a12c81f4/sites/596cf062747820316ab83e56/exceptions/incidents/95)