### PR TITLE
Fix twitter image url due to missing host

### DIFF
--- a/lib/tilex_web/views/layout_view.ex
+++ b/lib/tilex_web/views/layout_view.ex
@@ -1,6 +1,6 @@
 defmodule TilexWeb.LayoutView do
   use TilexWeb, :view
-  import TilexWeb.Router.Helpers, only: [static_path: 2]
+  import TilexWeb.Endpoint, only: [static_url: 0]
   import Phoenix.Component, only: [live_flash: 2]
   alias Tilex.Blog.Post
 
@@ -43,17 +43,9 @@ defmodule TilexWeb.LayoutView do
   @default_twitter_card "til_twitter_card.png"
   @external_resource @default_twitter_card
 
-  def twitter_image_url(%Post{} = post) do
-    twitter_image_url("#{channel_name(post)}_twitter_card.png")
-  end
-
-  def twitter_image_url(card) when card in @twitter_cards do
-    static_path(TilexWeb.Endpoint, "/images/#{card}")
-  end
-
-  def twitter_image_url(_card) do
-    static_path(TilexWeb.Endpoint, "/images/#{@default_twitter_card}")
-  end
+  def twitter_image_url(%Post{} = p), do: twitter_image_url("#{channel_name(p)}_twitter_card.png")
+  def twitter_image_url(card) when card in @twitter_cards, do: static_url() <> "/images/#{card}"
+  def twitter_image_url(_card), do: static_url() <> "/images/#{@default_twitter_card}"
 
   defp channel_name(post) do
     case Ecto.assoc_loaded?(post.channel) do

--- a/test/features/visitor_views_post_test.exs
+++ b/test/features/visitor_views_post_test.exs
@@ -116,7 +116,8 @@ defmodule VisitorViewsPostTest do
       |> find(Query.css("meta[name='twitter:image']", visible: false))
       |> Element.attr("content")
 
-    assert image_url =~ "command_line_twitter_card.png"
+    assert image_url =~ "http"
+    assert image_url =~ "/images/command_line_twitter_card.png"
 
     assert session
            |> find(Query.css("meta[name='twitter:title']", visible: false))
@@ -140,10 +141,6 @@ defmodule VisitorViewsPostTest do
     post = Factory.insert!(:post, channel: popular_channel, title: title, body: body)
 
     session = visit(session, post_path(Endpoint, :show, post))
-
-    assert session
-           |> find(Query.css("meta[name='twitter:title']", visible: false))
-           |> Element.attr("content") == "Today I Learned: Some Title"
 
     twitter_description =
       session


### PR DESCRIPTION
- [x] Fix twitter image url due to missing host

<img width="476" alt="image" src="https://user-images.githubusercontent.com/317960/198323919-cbd3b48f-e087-4ace-a7fb-0f0b7a30730b.png">
