### PR TITLE
feat: add white background to create post form

### DIFF
--- a/assets/css/pages.css
+++ b/assets/css/pages.css
@@ -1,7 +1,9 @@
 #profile_edit form, #post_edit form {
+  background-color: white;
   max-width: 70rem;
   margin: 0 auto 5rem auto;
   padding: 0 1rem;
+  padding: 4vw;
 }
 #profile_edit .post .content_preview, #post_edit .post .content_preview {
   min-height: 5rem;

--- a/lib/tilex_web/templates/post/form.html.eex
+++ b/lib/tilex_web/templates/post/form.html.eex
@@ -1,4 +1,7 @@
 <%= form_for @changeset, @action, fn f -> %>
+  <header class='page_head'>
+    <h1>Create Post</h1>
+  </header>
   <dl>
     <dt>
       <%= label f, :title %> <%= error_tag f, :title %>

--- a/lib/tilex_web/templates/post/new.html.eex
+++ b/lib/tilex_web/templates/post/new.html.eex
@@ -1,6 +1,3 @@
 <section id="post_edit">
-  <header class='page_head'>
-    <h1>Create Post</h1>
-  </header>
   <%= render TilexWeb.PostView, "form.html", channels: @channels, changeset: @changeset, current_user: @current_user, action: Routes.post_path(@conn, :create) %>
 </section>


### PR DESCRIPTION
Adds a background color to the create post form, which helps with visibility given the new banner

<img width="1417" alt="Screenshot 2022-12-09 at 10 34 53 PM" src="https://user-images.githubusercontent.com/6542235/206827310-a044c72c-8eba-4243-8c04-2673646a9795.png">
