### PR TITLE
feat: add channel name to most viewed posts list

### DIFF
--- a/lib/tilex/tracking.ex
+++ b/lib/tilex/tracking.ex
@@ -38,12 +38,15 @@ defmodule Tilex.Tracking do
         req in subquery(requests),
         join: post in Tilex.Blog.Post,
         on: [slug: req.url_slug],
+        join: channel in Tilex.Blog.Channel,
+        on: [id: post.channel_id],
         order_by: [desc: req.view_count],
         limit: 10,
         select: %{
           title: post.title,
           url: req.url,
-          view_count: req.view_count
+          view_count: req.view_count,
+          channel_name: channel.name
         }
       )
 

--- a/lib/tilex_web/templates/stats/developer.html.eex
+++ b/lib/tilex_web/templates/stats/developer.html.eex
@@ -20,13 +20,14 @@
         <h1>Most Viewed Posts</h1>
       </header>
       <ul class="post_list">
-        <%= for %{title: title, url: url, view_count: view_count} <- @most_viewed_posts do %>
+        <%= for %{title: title, url: url, view_count: view_count, channel_name: channel_name} <- @most_viewed_posts do %>
           <li>
             <%= link(to: url) do %>
               <b>
                 <%= title %>
               </b>
               <small>
+                #<%= channel_name %>
                 <span>•</span>
                 <%= view_count %> views
               </small>


### PR DESCRIPTION
Adds the channel name to each item in the `Most Viewed Posts` list on `/developer/statistics`

<img width="934" alt="Screenshot 2022-12-09 at 11 03 19 PM" src="https://user-images.githubusercontent.com/6542235/206828138-965bced6-68c1-4466-a3f7-524fbd928e95.png">
