### PR TITLE
SEO improvements

### DIFF
--- a/lib/tilex/pageable.ex
+++ b/lib/tilex/pageable.ex
@@ -1,14 +1,8 @@
 defmodule Tilex.Pageable do
-  defmacro __using__(_params) do
-    quote do
-      import Tilex.Pageable
-    end
-  end
-
   def robust_page(%{"page" => page}) do
     case Integer.parse(page) do
-      :error -> 1
-      {integer, _remainder} -> integer
+      {integer, ""} -> integer
+      _ -> 1
     end
   end
 

--- a/lib/tilex/plug/set_canonical_url.ex
+++ b/lib/tilex/plug/set_canonical_url.ex
@@ -1,0 +1,15 @@
+defmodule Tilex.Plug.SetCanonicalUrl do
+  import Plug.Conn, only: [assign: 3]
+
+  def init([]), do: []
+
+  def call(%Plug.Conn{request_path: path} = conn, _default) do
+    canonical_url =
+      :tilex
+      |> Application.get_env(:canonical_domain)
+      |> URI.merge(path)
+      |> URI.to_string()
+
+    assign(conn, :canonical_url, canonical_url)
+  end
+end

--- a/lib/tilex/posts.ex
+++ b/lib/tilex/posts.ex
@@ -34,8 +34,6 @@ defmodule Tilex.Posts do
   end
 
   def random_post_by_channel(channel_name) do
-    channel = Repo.get_by!(Channel, name: channel_name)
-
     posts_count = 1
 
     query =
@@ -44,11 +42,13 @@ defmodule Tilex.Posts do
         order_by: fragment("random()"),
         join: channel in assoc(post, :channel),
         where: channel.name == ^channel_name,
-        limit: 1,
+        limit: ^posts_count,
         preload: [:channel, :developer]
       )
 
-    {Repo.all(query), posts_count, channel}
+    post = Repo.one(query)
+
+    {[post], posts_count, post.channel}
   end
 
   def by_developer(username, limit: limit) do

--- a/lib/tilex_web/controllers/api/post_controller.ex
+++ b/lib/tilex_web/controllers/api/post_controller.ex
@@ -4,7 +4,7 @@ defmodule TilexWeb.Api.PostController do
   "
 
   use TilexWeb, :controller
-  use Tilex.Pageable
+  import Tilex.Pageable
   alias Tilex.Posts
 
   @doc """

--- a/lib/tilex_web/controllers/channel_controller.ex
+++ b/lib/tilex_web/controllers/channel_controller.ex
@@ -1,14 +1,10 @@
 defmodule TilexWeb.ChannelController do
   use TilexWeb, :controller
-
+  import Tilex.Pageable
   alias Tilex.Posts
 
   def show(conn, %{"name" => channel_name} = params) do
-    page =
-      params
-      |> Map.get("page", "1")
-      |> String.to_integer()
-
+    page = robust_page(params)
     {posts, posts_count, channel} = Posts.by_channel(channel_name, page)
 
     render(

--- a/lib/tilex_web/controllers/channel_controller.ex
+++ b/lib/tilex_web/controllers/channel_controller.ex
@@ -7,6 +7,12 @@ defmodule TilexWeb.ChannelController do
     page = robust_page(params)
     {posts, posts_count, channel} = Posts.by_channel(channel_name, page)
 
+    conn =
+      case page do
+        1 -> conn
+        _ -> assign(conn, :meta_robots, "noindex")
+      end
+
     render(
       conn,
       "show.html",
@@ -21,8 +27,9 @@ defmodule TilexWeb.ChannelController do
   def random_by_channel(conn, %{"channel" => channel_name}) do
     {posts, posts_count, channel} = Posts.random_post_by_channel(channel_name)
 
-    render(
-      conn,
+    conn
+    |> assign(:meta_robots, "noindex")
+    |> render(
       "show.html",
       posts: posts,
       posts_count: posts_count,

--- a/lib/tilex_web/controllers/developer_controller.ex
+++ b/lib/tilex_web/controllers/developer_controller.ex
@@ -1,17 +1,13 @@
 defmodule TilexWeb.DeveloperController do
   use TilexWeb, :controller
-
+  import Tilex.Pageable
   alias Tilex.Blog.Developer
   alias Tilex.Posts
   alias Tilex.Repo
   alias Tilex.Auth
 
   def show(conn, %{"name" => username} = params) do
-    page =
-      params
-      |> Map.get("page", "1")
-      |> String.to_integer()
-
+    page = robust_page(params)
     {posts, posts_count, developer} = Posts.by_developer(username, page)
 
     render(

--- a/lib/tilex_web/controllers/developer_controller.ex
+++ b/lib/tilex_web/controllers/developer_controller.ex
@@ -10,8 +10,9 @@ defmodule TilexWeb.DeveloperController do
     page = robust_page(params)
     {posts, posts_count, developer} = Posts.by_developer(username, page)
 
-    render(
-      conn,
+    conn
+    |> assign(:meta_robots, "noindex")
+    |> render(
       "show.html",
       posts: posts,
       posts_count: posts_count,

--- a/lib/tilex_web/controllers/post_controller.ex
+++ b/lib/tilex_web/controllers/post_controller.ex
@@ -67,7 +67,6 @@ defmodule TilexWeb.PostController do
       |> Repo.preload([:developer])
 
     conn
-    |> assign_post_canonical_url(post)
     |> assign(:twitter_shareable, true)
     |> render(:show, post: post)
   end
@@ -215,16 +214,6 @@ defmodule TilexWeb.PostController do
 
   defp extracted_slug(<<slug::size(10)-binary, _rest::binary>>), do: {:ok, slug}
   defp extracted_slug(_), do: :error
-
-  defp assign_post_canonical_url(conn, post) do
-    canonical_post =
-      :tilex
-      |> Application.get_env(:canonical_domain)
-      |> URI.merge(Routes.post_path(conn, :show, post))
-      |> URI.to_string()
-
-    assign(conn, :canonical_url, canonical_post)
-  end
 
   defp post_params(params) do
     Map.take(params, ["body", "channel_id", "title"])

--- a/lib/tilex_web/controllers/post_controller.ex
+++ b/lib/tilex_web/controllers/post_controller.ex
@@ -32,8 +32,9 @@ defmodule TilexWeb.PostController do
     page = robust_page(params)
     {posts, posts_count} = Posts.by_search(search_query, page)
 
-    render(
-      conn,
+    conn
+    |> assign(:meta_robots, "noindex")
+    |> render(
       "search_results.html",
       posts: posts,
       posts_count: posts_count,
@@ -48,6 +49,12 @@ defmodule TilexWeb.PostController do
   def index(conn, params) do
     page = robust_page(params)
     posts = Posts.all(page)
+
+    conn =
+      case page do
+        1 -> conn
+        _ -> assign(conn, :meta_robots, "noindex")
+      end
 
     render(conn, "index.html", posts: posts, page: page)
   end
@@ -77,7 +84,7 @@ defmodule TilexWeb.PostController do
     post = Repo.one(query)
 
     conn
-    |> assign_post_canonical_url(post)
+    |> assign(:meta_robots, "noindex")
     |> assign(:twitter_shareable, true)
     |> render("show.html", post: post)
   end
@@ -216,8 +223,7 @@ defmodule TilexWeb.PostController do
       |> URI.merge(Routes.post_path(conn, :show, post))
       |> URI.to_string()
 
-    conn
-    |> assign(:canonical_url, canonical_post)
+    assign(conn, :canonical_url, canonical_post)
   end
 
   defp post_params(params) do

--- a/lib/tilex_web/controllers/post_controller.ex
+++ b/lib/tilex_web/controllers/post_controller.ex
@@ -1,9 +1,8 @@
 defmodule TilexWeb.PostController do
   use TilexWeb, :controller
-  use Tilex.Pageable
+  import Tilex.Pageable
   import Ecto.Query
 
-  alias Guardian.Plug
   alias Tilex.Blog.Channel
   alias Tilex.Notifications
   alias Tilex.Liking
@@ -14,7 +13,7 @@ defmodule TilexWeb.PostController do
   plug(:extract_slug when action in [:show, :edit, :update])
 
   plug(
-    Plug.EnsureAuthenticated,
+    Guardian.Plug.EnsureAuthenticated,
     [error_handler: __MODULE__]
     when action in ~w(new create edit update)a
   )
@@ -84,7 +83,7 @@ defmodule TilexWeb.PostController do
   end
 
   def new(conn, _params) do
-    current_user = Plug.current_resource(conn)
+    current_user = Guardian.Plug.current_resource(conn)
     changeset = Post.changeset(%Post{})
 
     conn
@@ -110,7 +109,7 @@ defmodule TilexWeb.PostController do
   end
 
   def create(conn, %{"post" => params}) do
-    developer = Plug.current_resource(conn)
+    developer = Guardian.Plug.current_resource(conn)
 
     sanitized_params =
       params
@@ -136,7 +135,7 @@ defmodule TilexWeb.PostController do
   end
 
   def edit(conn, _params) do
-    current_user = Plug.current_resource(conn)
+    current_user = Guardian.Plug.current_resource(conn)
 
     post =
       case current_user.admin do
@@ -159,7 +158,7 @@ defmodule TilexWeb.PostController do
   end
 
   def update(conn, %{"post" => params}) do
-    current_user = Plug.current_resource(conn)
+    current_user = Guardian.Plug.current_resource(conn)
 
     post =
       case current_user.admin do

--- a/lib/tilex_web/controllers/sitemap_controller.ex
+++ b/lib/tilex_web/controllers/sitemap_controller.ex
@@ -4,6 +4,7 @@ defmodule TilexWeb.SitemapController do
   def index(conn, _) do
     conn
     |> assign(:posts, Repo.all(Tilex.Blog.Post))
+    |> assign(:channels, Repo.all(Tilex.Blog.Channel))
     |> put_layout(false)
     |> render("sitemap.xml")
   end

--- a/lib/tilex_web/controllers/stats_controller.ex
+++ b/lib/tilex_web/controllers/stats_controller.ex
@@ -22,6 +22,7 @@ defmodule TilexWeb.StatsController do
   def index(conn, _) do
     conn
     |> assign(:page_title, "Statistics")
+    |> assign(:meta_robots, "noindex")
     |> render("index.html", Stats.all())
   end
 

--- a/lib/tilex_web/router.ex
+++ b/lib/tilex_web/router.ex
@@ -7,6 +7,7 @@ defmodule TilexWeb.Router do
 
   pipeline :browser do
     plug Tilex.Plug.RequestRejector
+    plug Tilex.Plug.SetCanonicalUrl
     plug :accepts, ["html"]
     plug :fetch_session
     plug :fetch_live_flash

--- a/lib/tilex_web/templates/layout/root.html.heex
+++ b/lib/tilex_web/templates/layout/root.html.heex
@@ -35,6 +35,10 @@
     <meta name="twitter:site" content={"@#{Application.get_env(:tilex, :default_twitter_handle)}"}>
     <meta name="twitter:title" content={twitter_title(assigns[:post])}>
 
+    <%= if assigns[:meta_robots] do %>
+      <meta name="robots" content={assigns[:meta_robots]}>
+    <% end %>
+
     <link href='//fonts.googleapis.com/css?family=Raleway:700,900&display=swap' rel='stylesheet' type='text/css'>
     <link rel="alternate" type="application/rss+xml" title="Today I Learned" href={Routes.feed_path(@conn, :index)}>
 

--- a/lib/tilex_web/templates/sitemap/sitemap.xml.eex
+++ b/lib/tilex_web/templates/sitemap/sitemap.xml.eex
@@ -1,16 +1,24 @@
 
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
-<url>
-<loc>https://hashrocket.com/</loc>
-<changefreq>daily</changefreq>
-<priority>1.0</priority>
-</url>
+  <url>
+    <loc>https://hashrocket.com/</loc>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
 
-<%= for post <- @posts do %>
-<url>
-<loc><%= Routes.post_url(@conn, :show, post) %></loc>
-<changefreq>monthly</changefreq>
-<priority>0.5</priority>
-</url>
-<% end %>
+  <%= for post <- @posts do %>
+    <url>
+      <loc><%= Routes.post_url(@conn, :show, post) %></loc>
+      <changefreq>monthly</changefreq>
+      <priority>0.8</priority>
+    </url>
+  <% end %>
+
+  <%= for channel <- @channels do %>
+    <url>
+      <loc><%= Routes.channel_url(@conn, :show, channel) %></loc>
+      <changefreq>daily</changefreq>
+      <priority>0.4</priority>
+    </url>
+  <% end %>
 </urlset>

--- a/priv/static/robots.txt
+++ b/priv/static/robots.txt
@@ -1,5 +1,24 @@
-# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /
+# See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+
+sitemap: https://til.hashrocket.com/sitemap.xml
+
+User-agent: *
+Disallow: /*?*page=*
+
+User-agent: *
+Disallow: /*?*q=*
+
+User-agent: *
+Disallow: /statistics*
+
+User-agent: *
+Disallow: /authors/*
+
+User-agent: *
+Disallow: /random*
+
+User-agent: *
+Disallow: /*/random*
+
+User-agent: *
+Disallow: /*.md*

--- a/test/lib/tilex/plug/set_canonical_url_test.exs
+++ b/test/lib/tilex/plug/set_canonical_url_test.exs
@@ -1,0 +1,31 @@
+defmodule Tilex.Plug.SetCanonicalUrlTest do
+  use TilexWeb.ConnCase, async: true
+
+  alias Tilex.Plug.SetCanonicalUrl
+
+  @base Application.compile_env(:tilex, :canonical_domain)
+
+  @urls [
+    {"/", %{}, "#{@base}/"},
+    {"/", %{"foo" => "bar"}, "#{@base}/"},
+    {"/123-some-post", %{}, "#{@base}/123-some-post"},
+    {"/123-some-post", %{"foo" => "bar"}, "#{@base}/123-some-post"}
+  ]
+
+  describe "call/2" do
+    for {path, query, canonical} <- @urls do
+      @path path
+      @query query
+      @canonical canonical
+
+      test "sets canonical url for: '#{@path}' with '#{inspect(@query)}'" do
+        conn =
+          :get
+          |> build_conn(@path, @query)
+          |> SetCanonicalUrl.call([])
+
+        assert conn.assigns.canonical_url == @canonical
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Motivation

we found so much trash indexed urls in the google search console that we decided to review SEO for `tilex` and we come up with this PR. We are expecting to reduce the number of indexed page from 3.5K pages to about 600. That might improve the rank of our posts on search engines in general.

## Changes

- [x] add the sitemap entry to the `robots.txt` file
- [x] add channels show page to the `sitemap.xml`
- [x] remove some pages from bots index via `robots.txt`
- [x] set a few meta robots `noindex`
- [x] set canonical url on all pages and ignore query string by default
- [x] refactor: avoid unecessary join on channels random
- [x] refactor: reuse `Tilex.Pageable` on all controllers

---

# I'll revisit Google Search Console in a few weeks to check the new index situation

| before | after |
| --- | --- |
| <img width="891" alt="image" src="https://user-images.githubusercontent.com/1071893/207426668-f7b54092-facf-410a-8f31-1475ffa45154.png"> | |
| <img width="931" alt="image" src="https://user-images.githubusercontent.com/1071893/207426744-a13c7751-52cc-44bd-8c29-98a47e3509ea.png"> | |
| <img width="910" alt="image" src="https://user-images.githubusercontent.com/1071893/207427056-ebcc60da-3b0d-4833-b2b7-92e401213e14.png"> | |

## See also

https://search.google.com/