### PR TITLE
Add structured data for Rich Search 

### DIFF
--- a/lib/tilex_web/controllers/post_controller.ex
+++ b/lib/tilex_web/controllers/post_controller.ex
@@ -2,6 +2,7 @@ defmodule TilexWeb.PostController do
   use TilexWeb, :controller
   import Tilex.Pageable
   import Ecto.Query
+  import TilexWeb.StructuredDataView, only: [post_ld: 2]
 
   alias Tilex.Blog.Channel
   alias Tilex.Notifications
@@ -68,6 +69,7 @@ defmodule TilexWeb.PostController do
 
     conn
     |> assign(:twitter_shareable, true)
+    |> assign(:structured_data_ld, post_ld(conn, post))
     |> render(:show, post: post)
   end
 

--- a/lib/tilex_web/templates/layout/root.html.heex
+++ b/lib/tilex_web/templates/layout/root.html.heex
@@ -18,6 +18,10 @@
     <meta itemprop="brand" content="Today I Learned">
     <meta itemprop="description" content={description} />
 
+    <script type="application/ld+json">
+      <%= assigns |> Map.get_lazy(:structured_data_ld, &organization_ld/0) |> to_json() |> raw() %>
+    </script>
+
     <meta name="author" content={Application.get_env(:tilex, :organization_name)}>
     <meta name="description" content={description}>
     <meta name="format-detection" content="telephone=no">

--- a/lib/tilex_web/views/layout_view.ex
+++ b/lib/tilex_web/views/layout_view.ex
@@ -2,11 +2,16 @@ defmodule TilexWeb.LayoutView do
   use TilexWeb, :view
   import TilexWeb.Endpoint, only: [static_url: 0]
   import Phoenix.Component, only: [live_flash: 2]
+  import TilexWeb.StructuredDataView, only: [organization_ld: 0]
   alias Tilex.Blog.Post
 
   # Phoenix LiveDashboard is available only in development by default,
   # so we instruct Elixir to not warn if the dashboard route is missing.
   @compile {:no_warn_undefined, {Routes, :live_dashboard_path, 2}}
+
+  def to_json(data) do
+    Phoenix.json_library().encode_to_iodata!(data)
+  end
 
   def current_user(conn) do
     Guardian.Plug.current_resource(conn)

--- a/lib/tilex_web/views/structured_data_view.ex
+++ b/lib/tilex_web/views/structured_data_view.ex
@@ -1,0 +1,77 @@
+defmodule TilexWeb.StructuredDataView do
+  alias TilexWeb.Router.Helpers, as: Routes
+  alias Tilex.Blog.Post
+
+  @organization_ld %{
+    "@context" => "http://schema.org",
+    "@type" => "Organization",
+    "name" => "Hashrocket",
+    "url" => "https://hashrocket.com",
+    "image" => "https://hashrocket.com/hashrocket_logo.svg",
+    "logo" => "https://hashrocket.com/hashrocket_logo.svg",
+    "telephone" => "1-904-339-7047",
+    "duns" => "015835393",
+    "foundingDate" => "2008-01-22",
+    "founder" => %{
+      "@type" => "Person",
+      "url" => "http://marianphelan.com",
+      "name" => "Marian Phelan",
+      "jobTitle" => "CEO"
+    },
+    "brand" => %{
+      "@type" => "Brand",
+      "name" => "Hashrocket",
+      "url" => "https://hashrocket.com",
+      "logo" => "https://hashrocket.com/hashrocket_logo.svg"
+    },
+    "address" => %{
+      "@type" => "PostalAddress",
+      "streetAddress" => "320 1st St. N #714",
+      "addressLocality" => "Jacksonville Beach",
+      "addressRegion" => "FL",
+      "postalCode" => "32250",
+      "addressCountry" => "US"
+    },
+    "sameAs" => [
+      "https://clutch.co/profile/hashrocket",
+      "https://coderwall.com/team/hashrocket",
+      "https://dribbble.com/hashrocket",
+      "https://www.facebook.com/hashrocket",
+      "https://github.com/hashrocket",
+      "https://plus.google.com/+hashrocket",
+      "https://www.linkedin.com/company/hashrocket",
+      "https://twitter.com/hashrocket",
+      "https://www.youtube.com/hashrocket",
+      "https://vimeo.com/hashrocket"
+    ]
+  }
+
+  def organization_ld, do: @organization_ld
+
+  def post_ld(conn, %Post{channel: channel, developer: developer} = post) do
+    author_same_as =
+      case developer.twitter_handle do
+        nil -> []
+        handle -> ["https://twitter.com/#{handle}"]
+      end
+
+    %{
+      "@context" => "http://schema.org",
+      "@type" => "BlogPosting",
+      "headline" => post.title,
+      "articleBody" => post.body,
+      "articleSection" => channel.name,
+      "mainEntityOfPage" => Routes.post_url(conn, :show, post),
+      "image" => Routes.static_url(conn, "/images/til-logo-512x512.png"),
+      "datePublished" => DateTime.to_date(post.inserted_at),
+      "dateModified" => DateTime.to_date(post.updated_at),
+      "author" => %{
+        "@type" => "Person",
+        "name" => developer.username,
+        "url" => Routes.developer_url(conn, :show, developer),
+        "sameAs" => author_same_as
+      },
+      "publisher" => @organization_ld
+    }
+  end
+end


### PR DESCRIPTION
- [x] Add LD structured data for post with fallback to org

structured data helps search engines like google to display better results to the final user

## References

- [Structured Data Doc](https://developers.google.com/search/docs/appearance/structured-data/article)
- [Schema Validator](https://validator.schema.org/)
- [Rich Results Test](https://search.google.com/test/rich-results)

---

<img width="811" alt="image" src="https://user-images.githubusercontent.com/1071893/207710722-8f25afbf-d676-4cd6-a3bc-08f0dcc997d7.png">
<img width="936" alt="image" src="https://user-images.githubusercontent.com/1071893/207710802-8422f1f4-b507-4103-a9b3-a2b6b9412a2a.png">
<img width="797" alt="image" src="https://user-images.githubusercontent.com/1071893/207710958-ded92737-88ba-42ae-b94a-6c15a97284bd.png">
<img width="929" alt="image" src="https://user-images.githubusercontent.com/1071893/207710990-bbcb156c-d850-42d8-8410-f16ec2534bcd.png">
<img width="458" alt="image" src="https://user-images.githubusercontent.com/1071893/207711181-9307ea0e-8b54-4c07-be38-01331d369ab4.png">
