### PR TITLE
Remove article body from structured data

### DIFF
--- a/lib/tilex_web/templates/layout/root.html.heex
+++ b/lib/tilex_web/templates/layout/root.html.heex
@@ -19,7 +19,7 @@
     <meta itemprop="description" content={description} />
 
     <script type="application/ld+json">
-      <%= assigns |> Map.get_lazy(:structured_data_ld, &organization_ld/0) |> to_json() |> raw() %>
+      <%= assigns |> Map.get_lazy(:structured_data_ld, &organization_ld/0) |> to_ld_json() %>
     </script>
 
     <meta name="author" content={Application.get_env(:tilex, :organization_name)}>

--- a/lib/tilex_web/views/layout_view.ex
+++ b/lib/tilex_web/views/layout_view.ex
@@ -2,16 +2,12 @@ defmodule TilexWeb.LayoutView do
   use TilexWeb, :view
   import TilexWeb.Endpoint, only: [static_url: 0]
   import Phoenix.Component, only: [live_flash: 2]
-  import TilexWeb.StructuredDataView, only: [organization_ld: 0]
+  import TilexWeb.StructuredDataView, only: [to_ld_json: 1, organization_ld: 0]
   alias Tilex.Blog.Post
 
   # Phoenix LiveDashboard is available only in development by default,
   # so we instruct Elixir to not warn if the dashboard route is missing.
   @compile {:no_warn_undefined, {Routes, :live_dashboard_path, 2}}
-
-  def to_json(data) do
-    Phoenix.json_library().encode_to_iodata!(data)
-  end
 
   def current_user(conn) do
     Guardian.Plug.current_resource(conn)

--- a/lib/tilex_web/views/structured_data_view.ex
+++ b/lib/tilex_web/views/structured_data_view.ex
@@ -1,4 +1,5 @@
 defmodule TilexWeb.StructuredDataView do
+  use TilexWeb, :view
   alias TilexWeb.Router.Helpers, as: Routes
   alias Tilex.Blog.Post
 
@@ -46,6 +47,8 @@ defmodule TilexWeb.StructuredDataView do
     ]
   }
 
+  def to_ld_json(data), do: data |> to_json() |> raw()
+
   def organization_ld, do: @organization_ld
 
   def post_ld(conn, %Post{channel: channel, developer: developer} = post) do
@@ -59,7 +62,6 @@ defmodule TilexWeb.StructuredDataView do
       "@context" => "http://schema.org",
       "@type" => "BlogPosting",
       "headline" => post.title,
-      "articleBody" => post.body,
       "articleSection" => channel.name,
       "mainEntityOfPage" => Routes.post_url(conn, :show, post),
       "image" => Routes.static_url(conn, "/images/til-logo-512x512.png"),
@@ -74,4 +76,6 @@ defmodule TilexWeb.StructuredDataView do
       "publisher" => @organization_ld
     }
   end
+
+  defp to_json(data), do: Phoenix.json_library().encode!(data)
 end

--- a/test/views/structured_data_view_test.exs
+++ b/test/views/structured_data_view_test.exs
@@ -1,0 +1,23 @@
+defmodule Tilex.StructuredDataViewTest do
+  use ExUnit.Case, async: true
+  alias TilexWeb.StructuredDataView
+
+  @ld_json_data [
+    {%{}, "{}"},
+    {%{foo: :bar}, "{\"foo\":\"bar\"}"},
+    {%{foo: nil}, "{\"foo\":null}"},
+    {%{foo: []}, "{\"foo\":[]}"},
+    {%{foo: [1, "a"]}, "{\"foo\":[1,\"a\"]}"}
+  ]
+
+  describe "to_ld_json" do
+    for {input, output} <- @ld_json_data do
+      @input input
+      @output output
+
+      test "renders ld_json from data: '#{inspect(@input)}'" do
+        assert StructuredDataView.to_ld_json(@input) == {:safe, @output}
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Motivation

There's an issue with some TIL posts which has some content like `<script>` and as the `articleBody` was not sanitized properly that tag was early closing that `ld+json` script for the structured data. My goal for now is just remove that `articleBody` also because I think that's not needed for `BlogPosting`. I'm going to keep an eye on google indexing and we might come back to that later on with a proper `script` escaping if needed.